### PR TITLE
Add methods to clone FAR objects

### DIFF
--- a/FerramAerospaceResearch/FARAeroComponents/FARAeroPartModule.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/FARAeroPartModule.cs
@@ -52,12 +52,13 @@ using KSP.Localization;
 using FerramAerospaceResearch;
 using FerramAerospaceResearch.FARGUI;
 using FerramAerospaceResearch.FARGUI.FARFlightGUI;
+using FerramAerospaceResearch.FARUtils;
 using ferram4;
 
 namespace FerramAerospaceResearch.FARAeroComponents
 {
     //Used to hold relevant aero data for each part before applying it
-    public class FARAeroPartModule : PartModule, ILiftProvider
+    public class FARAeroPartModule : FARCloneablePartModule, ILiftProvider
     {
         public Vector3 partLocalVel;
         public Vector3 partLocalVelNorm;
@@ -160,6 +161,8 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
             }
         }
+
+        public FARAeroPartModule() : base() { }
 
         public void SetShielded(bool value)
         {
@@ -780,5 +783,54 @@ namespace FerramAerospaceResearch.FARAeroComponents
             legacyWingModel = null;
             stockAeroSurfaceModule = null;
         }
+
+        protected FARAeroPartModule(FARAeroPartModule other, Dictionary<Guid, object> cache) : base(other, cache)
+        {
+            partLocalVel = other.partLocalVel;
+            partLocalVelNorm = other.partLocalVelNorm;
+            partLocalAngVel = other.partLocalAngVel;
+
+            worldSpaceVelNorm = other.worldSpaceVelNorm;
+            worldSpaceAeroForce = other.worldSpaceAeroForce;
+            worldSpaceTorque = other.worldSpaceTorque;
+
+            totalWorldSpaceAeroForce = other.totalWorldSpaceAeroForce;
+
+            partLocalForce = other.partLocalForce;
+            partLocalTorque = other.partLocalTorque;
+
+            hackWaterDragVal = other.hackWaterDragVal;
+
+            // structs are copied on assignment
+            projectedArea = other.projectedArea;
+
+            partStressOverride = other.partStressOverride;
+            partStressMaxY = other.partStressMaxY;
+            partStressMaxXZ = other.partStressMaxXZ;
+            partForceMaxY = other.partForceMaxY;
+            partForceMaxXZ = other.partForceMaxXZ;
+
+            // don't copy arrow pointer right now
+            liftArrow = null;
+            dragArrow = null;
+            momentArrow = null;
+
+            fieldsVisible = other.fieldsVisible;
+
+            dragForce = other.dragForce;
+
+            liftForce = other.liftForce;
+
+            partTransform = other.partTransform;
+
+            materialColorUpdater = other.materialColorUpdater;
+            legacyWingModel = FARCloneHelper.Clone<FARWingAerodynamicModel>(other.legacyWingModel, cache);
+
+            // shallow copy as it is not mutated
+            stockAeroSurfaceModule = other.stockAeroSurfaceModule;
+        }
+
+        public override object Clone(IFARCloneable other, Dictionary<Guid, object> cache) => new FARAeroPartModule((FARAeroPartModule)other, cache);
+
     }
 }

--- a/FerramAerospaceResearch/FARFloatCurve.cs
+++ b/FerramAerospaceResearch/FARFloatCurve.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
+using FerramAerospaceResearch.FARUtils;
 
 namespace FerramAerospaceResearch
 {
     //recyclable float curve
-    class FARFloatCurve
+    class FARFloatCurve : IFARCloneable
     {
         struct CubicSection
         {
@@ -79,12 +81,14 @@ namespace FerramAerospaceResearch
             }
         }
 
+        private FARCloneHelper _cloneHelper;
         Vector3d[] controlPoints;
         CubicSection[] sections;
         int centerIndex;
 
-        private FARFloatCurve() { }
-        public FARFloatCurve(int numControlPoints)
+        private FARFloatCurve() => _cloneHelper = new FARCloneHelper();
+
+        public FARFloatCurve(int numControlPoints) : this()
         {
             controlPoints = new Vector3d[numControlPoints];
 
@@ -201,5 +205,44 @@ namespace FerramAerospaceResearch
                 sections[i] = tmpSection;
             }
         }
+
+        protected FARCloneHelper cloneHelper
+        {
+            get
+            {
+                if (_cloneHelper == null)
+                    _cloneHelper = new FARCloneHelper();
+                return _cloneHelper;
+            }
+        }
+
+        public Guid GUID
+        {
+            get
+            {
+                return cloneHelper.GUID;
+            }
+        }
+
+        public bool isClone
+        {
+            get
+            {
+                return cloneHelper.isClone;
+            }
+        }
+
+        protected FARFloatCurve(FARFloatCurve other, Dictionary<Guid, object> cache)
+        {
+            _cloneHelper = new FARCloneHelper(other, this, cache);
+
+            controlPoints = FARCloneHelper.ShallowCopy(other.controlPoints);
+            sections = FARCloneHelper.ShallowCopy(other.sections);  // structs are copied on assignment so this is the same as deep copy
+            centerIndex = other.centerIndex;
+        }
+
+        public T Clone<T>() where T : IFARCloneable => FARCloneHelper.Clone<T>(this);
+        public T Clone<T>(Dictionary<Guid, object> cache) where T : IFARCloneable => FARCloneHelper.Clone<T>(this, cache);
+        public virtual object Clone(IFARCloneable other, Dictionary<Guid, object> cache) => new FARFloatCurve((FARFloatCurve)other, cache);
     }
 }

--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSim.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSim.cs
@@ -62,6 +62,12 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
         public double _maxCrossSectionFromBody;
         public double _bodyLength;
 
+        public double area;
+        public double MAC;
+        public double b_2;
+        public Vector3d CoM;
+        public double mass;
+
         public InstantConditionSim() => _cloneHelper = new FARCloneHelper();
         public bool Ready
         {
@@ -87,20 +93,11 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
             return accel;
         }
 
-        public void GetClCdCmSteady(InstantConditionSimInput input, out InstantConditionSimOutput output, bool clear, bool reset_stall = false)
+        public void PrecomputeVessel()
         {
-            output = new InstantConditionSimOutput();
+            CoM = Vector3d.zero;
+            mass = 0;
 
-            double area = 0;
-            double MAC = 0;
-            double b_2 = 0;
-
-            Vector3d forward = Vector3.forward;
-            Vector3d up = Vector3.up;
-            Vector3d right = Vector3.right;
-
-            Vector3d CoM = Vector3d.zero;
-            double mass = 0;
             List<Part> partsList = EditorLogic.SortedShipList;
             for (int i = 0; i < partsList.Count; i++)
             {
@@ -119,6 +116,21 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
                 mass += partMass;
             }
             CoM /= mass;
+        }
+
+        public void GetClCdCmSteady(InstantConditionSimInput input, out InstantConditionSimOutput output, bool clear, bool reset_stall = false)
+        {
+            output = new InstantConditionSimOutput();
+
+            area = 0;
+            MAC = 0;
+            b_2 = 0;
+
+            Vector3d forward = Vector3.forward;
+            Vector3d up = Vector3.up;
+            Vector3d right = Vector3.right;
+
+            if (!isClone) PrecomputeVessel();
 
             if (EditorDriver.editorFacility == EditorFacility.VAB)
             {
@@ -337,6 +349,8 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
 
             iterationInput = FARCloneHelper.Clone<InstantConditionSimInput>(other.iterationInput, cache);
             iterationOutput = other.iterationOutput;
+
+            PrecomputeVessel();
         }
 
         public T Clone<T>() where T : IFARCloneable => FARCloneHelper.Clone<T>(this);

--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSim.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSim.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Ferram Aerospace Research v0.15.9.5 "Lighthill"
 =========================
 Aerodynamics model for Kerbal Space Program
@@ -48,11 +48,13 @@ using System.Linq;
 using UnityEngine;
 using ferram4;
 using FerramAerospaceResearch.FARAeroComponents;
+using FerramAerospaceResearch.FARUtils;
 
 namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
 {
-    class InstantConditionSim
+    class InstantConditionSim : IFARCloneable
     {
+        private FARCloneHelper _cloneHelper;
         List<FARAeroSection> _currentAeroSections;
         List<FARAeroPartModule> _currentAeroModules;
         List<FARWingAerodynamicModel> _wingAerodynamicModel;
@@ -60,6 +62,7 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
         public double _maxCrossSectionFromBody;
         public double _bodyLength;
 
+        public InstantConditionSim() => _cloneHelper = new FARCloneHelper();
         public bool Ready
         {
             get { return _currentAeroSections != null && _currentAeroModules != null && _wingAerodynamicModel != null; }
@@ -293,5 +296,51 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
             return iterationOutput.Cl - neededCl;
         }
 
+        protected FARCloneHelper cloneHelper
+        {
+            get
+            {
+                if (_cloneHelper == null)
+                    _cloneHelper = new FARCloneHelper();
+                return _cloneHelper;
+            }
+        }
+
+        public Guid GUID
+        {
+            get
+            {
+                return cloneHelper.GUID;
+            }
+        }
+
+        public bool isClone
+        {
+            get
+            {
+                return cloneHelper.isClone;
+            }
+        }
+
+        protected InstantConditionSim(InstantConditionSim other, Dictionary<Guid, object> cache)
+        {
+            _cloneHelper = new FARCloneHelper(other, this, cache);
+
+            _currentAeroSections = FARCloneHelper.DeepCopy(other._currentAeroSections, cache);
+            _currentAeroModules = FARCloneHelper.DeepCopy(other._currentAeroModules, cache);
+            _wingAerodynamicModel = FARCloneHelper.DeepCopy(other._wingAerodynamicModel, cache);
+
+            _maxCrossSectionFromBody = other._maxCrossSectionFromBody;
+            _bodyLength = other._bodyLength;
+
+            neededCl = other.neededCl;
+
+            iterationInput = FARCloneHelper.Clone<InstantConditionSimInput>(other.iterationInput, cache);
+            iterationOutput = other.iterationOutput;
+        }
+
+        public T Clone<T>() where T : IFARCloneable => FARCloneHelper.Clone<T>(this);
+        public T Clone<T>(Dictionary<Guid, object> cache) where T : IFARCloneable => FARCloneHelper.Clone<T>(this, cache);
+        public virtual object Clone(IFARCloneable other, Dictionary<Guid, object> cache) => new InstantConditionSim((InstantConditionSim)other, cache);
     }
 }

--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSim.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSim.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Ferram Aerospace Research v0.15.9.5 "Lighthill"
 =========================
 Aerodynamics model for Kerbal Space Program
@@ -158,7 +158,7 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
             for (int i = 0; i < _wingAerodynamicModel.Count; i++)
             {
                 FARWingAerodynamicModel w = _wingAerodynamicModel[i];
-                if (!(w && w.part))
+                if (!(!(w is null) && w.part))
                     continue;
 
                 w.ComputeForceEditor(velocity.normalized, input.machNumber, 2);

--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSimInput.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSimInput.cs
@@ -43,11 +43,14 @@ Copyright 2017, Michael Ferrara, aka Ferram4
  */
 
 using System;
+using System.Collections.Generic;
+using FerramAerospaceResearch.FARUtils;
 
 namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
 {
-    class InstantConditionSimInput
+    class InstantConditionSimInput : IFARCloneable
     {
+        private FARCloneHelper _cloneHelper;
         public double alpha;
         public double beta;
         public double phi;
@@ -59,9 +62,9 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
         public int flaps;
         public bool spoilers;
 
-        public InstantConditionSimInput() { }
+        public InstantConditionSimInput() => _cloneHelper = new FARCloneHelper();
 
-        public InstantConditionSimInput(double alpha, double beta, double phi, double alphaDot, double betaDot, double phiDot, double machNumber, double pitchValue)
+        public InstantConditionSimInput(double alpha, double beta, double phi, double alphaDot, double betaDot, double phiDot, double machNumber, double pitchValue) : this()
         {
             this.alpha = alpha;
             this.beta = beta;
@@ -76,7 +79,7 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
             spoilers = false;
         }
 
-        public InstantConditionSimInput(double alpha, double beta, double phi, double alphaDot, double betaDot, double phiDot, double machNumber, double pitchValue, int flaps, bool spoilers)
+        public InstantConditionSimInput(double alpha, double beta, double phi, double alphaDot, double betaDot, double phiDot, double machNumber, double pitchValue, int flaps, bool spoilers) : this()
         {
             this.alpha = alpha;
             this.beta = beta;
@@ -89,5 +92,51 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
             this.flaps = flaps;
             this.spoilers = spoilers;
         }
+
+        protected FARCloneHelper cloneHelper
+        {
+            get
+            {
+                if (_cloneHelper == null)
+                    _cloneHelper = new FARCloneHelper();
+                return _cloneHelper;
+            }
+        }
+
+        public Guid GUID
+        {
+            get
+            {
+                return cloneHelper.GUID;
+            }
+        }
+
+        public bool isClone
+        {
+            get
+            {
+                return cloneHelper.isClone;
+            }
+        }
+
+        protected InstantConditionSimInput(InstantConditionSimInput other, Dictionary<Guid, object> cache)
+        {
+            _cloneHelper = new FARCloneHelper(other, this, cache);
+
+            alpha = other.alpha;
+            beta = other.beta;
+            phi = other.phi;
+            alphaDot = other.alphaDot;
+            betaDot = other.betaDot;
+            phiDot = other.phiDot;
+            machNumber = other.machNumber;
+            pitchValue = other.pitchValue;
+            flaps = other.flaps;
+            spoilers = other.spoilers;
+        }
+
+        public T Clone<T>() where T : IFARCloneable => FARCloneHelper.Clone<T>(this);
+        public T Clone<T>(Dictionary<Guid, object> cache) where T : IFARCloneable => FARCloneHelper.Clone<T>(this, cache);
+        public virtual object Clone(IFARCloneable other, Dictionary<Guid, object> cache) => new InstantConditionSimInput((InstantConditionSimInput)other, cache);
     }
 }

--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/StabilityDerivCalculator.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/StabilityDerivCalculator.cs
@@ -102,7 +102,7 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
                 CoM += partMass * (Vector3d)p.transform.TransformPoint(p.CoMOffset);
                 mass += partMass;
                 FARWingAerodynamicModel w = p.GetComponent<FARWingAerodynamicModel>();
-                if (w != null)
+                if (!(w is null))
                 {
                     if (w.isShielded)
                         continue;

--- a/FerramAerospaceResearch/FARUtils/FARCloneHelper.cs
+++ b/FerramAerospaceResearch/FARUtils/FARCloneHelper.cs
@@ -1,0 +1,153 @@
+/*
+Ferram Aerospace Research v0.15.9.5 "Lighthill"
+=========================
+Copyright 2018, Daumantas Kavolis, aka dkavolis
+
+   This file is part of Ferram Aerospace Research.
+
+   Ferram Aerospace Research is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Ferram Aerospace Research is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Ferram Aerospace Research.  If not, see <http: //www.gnu.org/licenses/>.
+
+   Serious thanks:        a.g., for tons of bugfixes and code-refactorings
+                stupid_chris, for the RealChuteLite implementation
+                        Taverius, for correcting a ton of incorrect values
+                Tetryds, for finding lots of bugs and issues and not letting me get away with them, and work on example crafts
+                        sarbian, for refactoring code for working with MechJeb, and the Module Manager updates
+                        ialdabaoth (who is awesome), who originally created Module Manager
+                            Regex, for adding RPM support
+                DaMichel, for some ferramGraph updates and some control surface-related features
+                        Duxwing, for copy editing the readme
+
+   CompatibilityChecker by Majiir, BSD 2-clause http: //opensource.org/licenses/BSD-2-Clause
+
+   Part.cfg changes powered by sarbian & ialdabaoth's ModuleManager plugin; used with permission
+    http: //forum.kerbalspaceprogram.com/threads/55219
+
+   ModularFLightIntegrator by Sarbian, Starwaster and Ferram4, MIT: http: //opensource.org/licenses/MIT
+    http: //forum.kerbalspaceprogram.com/threads/118088
+
+   Toolbar integration powered by blizzy78's Toolbar plugin; used with permission
+    http: //forum.kerbalspaceprogram.com/threads/60863
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace FerramAerospaceResearch.FARUtils
+{
+    /// <summary>
+    /// A helper class for IFARCloneable&lt;T&gt; since C# 7.0 does not support multiple inheritance (it is allowed in
+    /// C# 8.0+). This should be used via object aggregation. The IFARCloneable implementing class should call
+    /// corresponding constructor and pass GUID getter, Clone() and Clone(cache) methods to an instance of
+    /// FARCloneHelper. Clone(other, cache) should redirect to a copy constructor with the same signature.
+    /// </summary>
+    public class FARCloneHelper
+    {
+        // Using guid for unique identifiers since it is thread safe. We could use a counter and an int ID
+        // but then counter increment and id setter would have to be manually locked for thread safety.
+        private Guid guid;
+        private bool cloned;
+
+        public Guid GUID
+        {
+            get
+            {
+                return guid;
+            }
+        }
+
+        public bool isClone
+        {
+            get
+            {
+                return cloned;
+            }
+        }
+
+        public FARCloneHelper() => guid = Guid.NewGuid();
+
+        /// <summary>
+        /// Constructor that additionally adds clone <paramref name="clone"/> of <paramref name="original"/> to <paramref name="cache"/>.
+        /// </summary>
+        /// <param name="original">Object being cloned.</param>
+        /// <param name="clone">Clone of <paramref name="original"/>.</param>
+        /// <param name="cache">Cache of cloned objects, keys are GUIDs of parents</param>
+        /// <example>
+        /// In copy constructor <c>T(IFARCloneable&lt;T> other, Dictionary&lt;Guid, object> cache)</c>:
+        /// <code>
+        /// this.cloner = new FARCloneHelper(other, this, cache);
+        /// </code>
+        /// </example>
+        public FARCloneHelper(IFARIdentifiable original, IFARIdentifiable clone, Dictionary<Guid, object> cache) : this()
+        {
+            cache.Add(original.GUID, clone);
+            cloned = true;
+        }
+
+        /// <summary>
+        /// Generic clone method. Instantiates an empty cache used to store references to cloned objects.
+        /// </summary>
+        /// <param name="original">Object to clone.</param>
+        /// <returns>Clone of the current object.</returns>
+        public static T Clone<T>(IFARCloneable original) where T : IFARCloneable
+        {
+            Dictionary<Guid, object> cache = new Dictionary<Guid, object>();
+            return Clone<T>(original, cache);
+        }
+
+        /// <summary>
+        /// Generic clone method that first searches the cache for the cloned object. Should be called from copy constructors.
+        /// </summary>
+        /// <param name="original">Object to clone.</param>
+        /// <param name="cache">Cache of cloned objects.</param>
+        /// <returns>Clone of <paramref name="original"/> of type <typeparamref name="T"/>.</returns>
+        public static T Clone<T>(IFARCloneable original, Dictionary<Guid, object> cache) where T : IFARCloneable
+        {
+            if (original == null)
+                return default(T);
+
+            object clone;
+            if (cache.TryGetValue(original.GUID, out clone))
+                return (T)clone;
+
+            if (original.isClone)
+                return (T)original;
+
+            if (!(original is T))
+                throw new ArgumentException($"Invalid argument type {original.GetType().FullName}, expected {typeof(T).FullName}.");
+
+            return (T)original.Clone(original, cache);
+        }
+
+        public static List<T> ShallowCopy<T>(List<T> other)
+        {
+            if (other == null)
+                return null;
+            return other.ShallowCopy();
+        }
+
+        public static T[] ShallowCopy<T>(T[] other)
+        {
+            if (other == null)
+                return null;
+            return other.ShallowCopy();
+        }
+
+        public static List<T> DeepCopy<T>(List<T> other, Dictionary<Guid, object> cache) where T : IFARCloneable
+        {
+            if (other == null)
+                return null;
+            return other.DeepCopy(cache);
+        }
+    }
+}

--- a/FerramAerospaceResearch/FARUtils/FARCloneablePartModule.cs
+++ b/FerramAerospaceResearch/FARUtils/FARCloneablePartModule.cs
@@ -1,0 +1,148 @@
+/*
+Ferram Aerospace Research v0.15.9.5 "Lighthill"
+=========================
+Copyright 2018, Daumantas Kavolis, aka dkavolis
+
+   This file is part of Ferram Aerospace Research.
+
+   Ferram Aerospace Research is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Ferram Aerospace Research is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Ferram Aerospace Research.  If not, see <http: //www.gnu.org/licenses/>.
+
+   Serious thanks:        a.g., for tons of bugfixes and code-refactorings
+                stupid_chris, for the RealChuteLite implementation
+                        Taverius, for correcting a ton of incorrect values
+                Tetryds, for finding lots of bugs and issues and not letting me get away with them, and work on example crafts
+                        sarbian, for refactoring code for working with MechJeb, and the Module Manager updates
+                        ialdabaoth (who is awesome), who originally created Module Manager
+                            Regex, for adding RPM support
+                DaMichel, for some ferramGraph updates and some control surface-related features
+                        Duxwing, for copy editing the readme
+
+   CompatibilityChecker by Majiir, BSD 2-clause http: //opensource.org/licenses/BSD-2-Clause
+
+   Part.cfg changes powered by sarbian & ialdabaoth's ModuleManager plugin; used with permission
+    http: //forum.kerbalspaceprogram.com/threads/55219
+
+   ModularFLightIntegrator by Sarbian, Starwaster and Ferram4, MIT: http: //opensource.org/licenses/MIT
+    http: //forum.kerbalspaceprogram.com/threads/118088
+
+   Toolbar integration powered by blizzy78's Toolbar plugin; used with permission
+    http: //forum.kerbalspaceprogram.com/threads/60863
+ */
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FerramAerospaceResearch.FARUtils
+{
+    public class FARCloneablePartModule : PartModule, IFARCloneable
+    {
+        private FARCloneHelper _cloneHelper;
+
+        // Override Component.tag and Component.transform since calling plain constructor won't create proper Unity objects
+        private Transform _transform;
+        private string _tag;
+
+        protected FARCloneHelper cloneHelper
+        {
+            get
+            {
+                if (_cloneHelper == null)
+                    _cloneHelper = new FARCloneHelper();
+                return _cloneHelper;
+            }
+        }
+
+        public Guid GUID
+        {
+            get
+            {
+                return cloneHelper.GUID;
+            }
+        }
+
+        public bool isClone
+        {
+            get
+            {
+                return cloneHelper.isClone;
+            }
+        }
+
+        public new Transform transform
+        {
+            get
+            {
+                if (_transform == null)
+                    return base.transform;
+                return _transform;
+            }
+        }
+
+        public new string tag
+        {
+            get
+            {
+                if (_tag == null)
+                    return base.tag;
+                return _tag;
+            }
+            set
+            {
+                if (_tag == null)
+                    base.tag = value;
+                else
+                    _tag = value;
+            }
+        }
+
+        public FARCloneablePartModule() : base()
+        {
+            _cloneHelper = new FARCloneHelper();
+        }
+
+        protected FARCloneablePartModule(FARCloneablePartModule other, Dictionary<Guid, object> cache) : base()
+        {
+            _cloneHelper = new FARCloneHelper(other, this, cache);
+
+            _transform = other.transform;
+            _tag = other.tag;
+
+            // Only do a shallow copy of KSP objects since they are not mutated here
+            part = other.part;
+            resHandler = other.resHandler;
+            upgradesApplied = FARCloneHelper.ShallowCopy(other.upgradesApplied);
+            showUpgradesInModuleInfo = other.showUpgradesInModuleInfo;
+            upgradesAsk = other.upgradesAsk;
+            moduleName = other.moduleName;
+            upgrades = other.upgrades;
+            upgradesApply = other.upgradesApply;
+            isEnabled = other.isEnabled;
+            snapshot = other.snapshot;
+            stagingToggleEnabledEditor = other.stagingToggleEnabledEditor;
+            stagingEnabled = other.stagingEnabled;
+            stagingEnableText = other.stagingEnableText;
+            stagingDisableText = other.stagingDisableText;
+            overrideStagingIconIfBlank = other.overrideStagingIconIfBlank;
+            moduleIsEnabled = other.moduleIsEnabled;
+            stagingToggleEnabledFlight = other.stagingToggleEnabledFlight;
+        }
+
+        public T Clone<T>() where T : IFARCloneable => FARCloneHelper.Clone<T>(this);
+
+        public T Clone<T>(Dictionary<Guid, object> cache) where T : IFARCloneable => FARCloneHelper.Clone<T>(this, cache);
+
+        public virtual object Clone(IFARCloneable other, Dictionary<Guid, object> cache) => new FARCloneablePartModule((FARCloneablePartModule)other, cache);
+    }
+}

--- a/FerramAerospaceResearch/FARUtils/FARCopyExtensions.cs
+++ b/FerramAerospaceResearch/FARUtils/FARCopyExtensions.cs
@@ -1,0 +1,78 @@
+/*
+Ferram Aerospace Research v0.15.9.5 "Lighthill"
+=========================
+Copyright 2018, Daumantas Kavolis, aka dkavolis
+
+   This file is part of Ferram Aerospace Research.
+
+   Ferram Aerospace Research is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Ferram Aerospace Research is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Ferram Aerospace Research.  If not, see <http: //www.gnu.org/licenses/>.
+
+   Serious thanks:        a.g., for tons of bugfixes and code-refactorings
+                stupid_chris, for the RealChuteLite implementation
+                        Taverius, for correcting a ton of incorrect values
+                Tetryds, for finding lots of bugs and issues and not letting me get away with them, and work on example crafts
+                        sarbian, for refactoring code for working with MechJeb, and the Module Manager updates
+                        ialdabaoth (who is awesome), who originally created Module Manager
+                            Regex, for adding RPM support
+                DaMichel, for some ferramGraph updates and some control surface-related features
+                        Duxwing, for copy editing the readme
+
+   CompatibilityChecker by Majiir, BSD 2-clause http: //opensource.org/licenses/BSD-2-Clause
+
+   Part.cfg changes powered by sarbian & ialdabaoth's ModuleManager plugin; used with permission
+    http: //forum.kerbalspaceprogram.com/threads/55219
+
+   ModularFLightIntegrator by Sarbian, Starwaster and Ferram4, MIT: http: //opensource.org/licenses/MIT
+    http: //forum.kerbalspaceprogram.com/threads/118088
+
+   Toolbar integration powered by blizzy78's Toolbar plugin; used with permission
+    http: //forum.kerbalspaceprogram.com/threads/60863
+ */
+
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace FerramAerospaceResearch.FARUtils
+{
+    public static class FARCopyExtensions
+    {
+        public static List<T> ShallowCopy<T>(this List<T> other)
+        {
+            List<T> list = new List<T>(other.Count);
+            foreach (T item in other)
+                list.Add(item);
+            return list;
+        }
+
+        public static T[] ShallowCopy<T>(this T[] other)
+        {
+            T[] list = new T[other.Length];
+            for (int i = 0; i < other.Length; i++)
+                list[i] = other[i];
+            return list;
+        }
+
+        public static List<T> DeepCopy<T>(this List<T> other, Dictionary<Guid, object> cache) where T : IFARCloneable
+        {
+            List<T> list = new List<T>(other.Count);
+            foreach (T item in other)
+                if (item == null)
+                    list.Add(default(T));
+                else
+                    list.Add(item.Clone<T>(cache));
+            return list;
+        }
+    }
+}

--- a/FerramAerospaceResearch/FARUtils/IFARCloneable.cs
+++ b/FerramAerospaceResearch/FARUtils/IFARCloneable.cs
@@ -1,0 +1,97 @@
+/*
+Ferram Aerospace Research v0.15.9.5 "Lighthill"
+=========================
+Copyright 2018, Daumantas Kavolis, aka dkavolis
+
+   This file is part of Ferram Aerospace Research.
+
+   Ferram Aerospace Research is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Ferram Aerospace Research is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Ferram Aerospace Research.  If not, see <http: //www.gnu.org/licenses/>.
+
+   Serious thanks:        a.g., for tons of bugfixes and code-refactorings
+                stupid_chris, for the RealChuteLite implementation
+                        Taverius, for correcting a ton of incorrect values
+                Tetryds, for finding lots of bugs and issues and not letting me get away with them, and work on example crafts
+                        sarbian, for refactoring code for working with MechJeb, and the Module Manager updates
+                        ialdabaoth (who is awesome), who originally created Module Manager
+                            Regex, for adding RPM support
+                DaMichel, for some ferramGraph updates and some control surface-related features
+                        Duxwing, for copy editing the readme
+
+   CompatibilityChecker by Majiir, BSD 2-clause http: //opensource.org/licenses/BSD-2-Clause
+
+   Part.cfg changes powered by sarbian & ialdabaoth's ModuleManager plugin; used with permission
+    http: //forum.kerbalspaceprogram.com/threads/55219
+
+   ModularFLightIntegrator by Sarbian, Starwaster and Ferram4, MIT: http: //opensource.org/licenses/MIT
+    http: //forum.kerbalspaceprogram.com/threads/118088
+
+   Toolbar integration powered by blizzy78's Toolbar plugin; used with permission
+    http: //forum.kerbalspaceprogram.com/threads/60863
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace FerramAerospaceResearch.FARUtils
+{
+
+    /// <summary>
+    /// An interface to uniquely indetify objects.
+    /// </summary>
+    public interface IFARIdentifiable
+    {
+        /// <summary>
+        /// Unique object identifier. GetHashCode is not guaranteed to be unique, see
+        /// <a href="https://docs.microsoft.com/en-us/dotnet/api/system.object.gethashcode?redirectedfrom=MSDN&view=netframework-4.7.2#System_Object_GetHashCode">here</a>
+        /// </summary>
+        Guid GUID { get; }
+
+        /// <summary>
+        /// Whether this object is a clone.
+        /// </summary>
+        bool isClone { get; }
+    }
+
+    /// <summary>
+    /// An interface that should clone the object by deep copying.
+    /// </summary>
+    public interface IFARCloneable : IFARIdentifiable
+    {
+        /// <summary>
+        /// Abstract method that should perform deep copy of the object.
+        /// </summary>
+        /// <returns>Clone of the implementing object.</returns>
+        T Clone<T>() where T : IFARCloneable;
+
+        /// <summary>
+        /// Abstract method that should perform deep copy of the object using the cloned object references in
+        /// <paramref name="cache"/>.
+        /// </summary>
+        /// <param name="cache">Dictionary of the cloned objects. Keys are the original objects GUIDs.</param>
+        /// <returns>Clone of the implementing object.</returns>
+        T Clone<T>(Dictionary<Guid, object> cache) where T : IFARCloneable;
+
+        /// <summary>
+        /// Abstract method that should perform deep copy of <paramref name="other"/> using the cloned object references.
+        /// Keeping the return and input types broad to allow for virtual implementation. Ideally, this method should
+        /// always be called from the other two - the first one initializing the cache and calling the second one,
+        /// and the second one calling this method with the current object as an argument.
+        /// in <paramref name="cache"/>.
+        /// </summary>
+        /// <param name="other">Object to copy.</param>
+        /// <param name="cache">Dictionary of the cloned objects. Keys are the original objects GUIDs.</param>
+        /// <returns>Clone of <paramref name="other"/>.</returns>
+        object Clone(IFARCloneable other, Dictionary<Guid, object> cache);
+    }
+}

--- a/FerramAerospaceResearch/FerramAerospaceResearch.csproj
+++ b/FerramAerospaceResearch/FerramAerospaceResearch.csproj
@@ -159,6 +159,7 @@
     <Compile Include="ToolbarWrapper.cs" />
     <Compile Include="FARUtils/FARLogger.cs" />
     <Compile Include="FARUtils/FARVersion.cs" />
+    <Compile Include="FARUtils/IFARCloneable.cs" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Service References\" />

--- a/FerramAerospaceResearch/FerramAerospaceResearch.csproj
+++ b/FerramAerospaceResearch/FerramAerospaceResearch.csproj
@@ -160,6 +160,7 @@
     <Compile Include="FARUtils/FARLogger.cs" />
     <Compile Include="FARUtils/FARVersion.cs" />
     <Compile Include="FARUtils/IFARCloneable.cs" />
+    <Compile Include="FARUtils/FARCopyExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Service References\" />

--- a/FerramAerospaceResearch/FerramAerospaceResearch.csproj
+++ b/FerramAerospaceResearch/FerramAerospaceResearch.csproj
@@ -160,6 +160,7 @@
     <Compile Include="FARUtils/FARLogger.cs" />
     <Compile Include="FARUtils/FARVersion.cs" />
     <Compile Include="FARUtils/IFARCloneable.cs" />
+    <Compile Include="FARUtils/FARCloneHelper.cs" />
     <Compile Include="FARUtils/FARCopyExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/FerramAerospaceResearch/FerramAerospaceResearch.csproj
+++ b/FerramAerospaceResearch/FerramAerospaceResearch.csproj
@@ -162,6 +162,7 @@
     <Compile Include="FARUtils/IFARCloneable.cs" />
     <Compile Include="FARUtils/FARCloneHelper.cs" />
     <Compile Include="FARUtils/FARCopyExtensions.cs" />
+    <Compile Include="FARUtils/FARCloneablePartModule.cs" />
   </ItemGroup>
   <ItemGroup>
     <WCFMetadata Include="Service References\" />

--- a/FerramAerospaceResearch/LEGACYferram4/FARBaseAerodynamics.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARBaseAerodynamics.cs
@@ -46,6 +46,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using FerramAerospaceResearch;
+using FerramAerospaceResearch.FARUtils;
 using KSP.Localization;
 
 namespace ferram4
@@ -84,6 +85,8 @@ namespace ferram4
 
         // Keep track if the tinting effect is active or not
         //private bool tintIsActive = false;
+
+        public FARBaseAerodynamics() : base() { }
 
         public override void OnAwake()
         {
@@ -232,5 +235,20 @@ namespace ferram4
             if (node.HasValue("S"))
                 double.TryParse(node.GetValue("S"), out S);
         }
+
+        protected FARBaseAerodynamics(FARBaseAerodynamics other, Dictionary<Guid, object> cache) : base(other, cache)
+        {
+            Cl = other.Cl;
+            Cd = other.Cd;
+            Cm = other.Cm;
+
+            velocityEditor = other.velocityEditor;
+            // shallow copy of transform, it is not edited
+            part_transform = other.part_transform;
+            S = other.S;
+            isShielded = other.isShielded;
+            rho = other.rho;
+        }
+        public override object Clone(IFARCloneable other, Dictionary<Guid, object> cache) => new FARBaseAerodynamics((FARBaseAerodynamics)other, cache);
     }
 }

--- a/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Ferram Aerospace Research v0.15.9.5 "Lighthill"
 =========================
 Aerodynamics model for Kerbal Space Program
@@ -597,17 +597,20 @@ namespace ferram4
             deflectedNormal.z = Math.Sqrt(tmp);
 
             // Visually animate the surface
-            MovableSection.localRotation = MovableOrig;
-            if (AoAoffset != 0)
+            if (!isClone)
             {
-                Quaternion localRot;
-                if (flipAxis)
-                    localRot = Quaternion.FromToRotation(deflectedNormal, new Vector3(0, 0, 1));
-                else
-                    localRot = Quaternion.FromToRotation(new Vector3(0, 0, 1), deflectedNormal);
+                MovableSection.localRotation = MovableOrig;
+                if (AoAoffset != 0)
+                {
+                    Quaternion localRot;
+                    if (flipAxis)
+                        localRot = Quaternion.FromToRotation(deflectedNormal, new Vector3(0, 0, 1));
+                    else
+                        localRot = Quaternion.FromToRotation(new Vector3(0, 0, 1), deflectedNormal);
 
-                MovableSection.localRotation *= localRot;
+                    MovableSection.localRotation *= localRot;
 
+                }
             }
             CheckShielded();
         }

--- a/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Ferram Aerospace Research v0.15.9.5 "Lighthill"
 =========================
 Aerodynamics model for Kerbal Space Program
@@ -48,6 +48,7 @@ using UnityEngine;
 using KSP;
 using KSP.Localization;
 using FerramAerospaceResearch;
+using FerramAerospaceResearch.FARUtils;
 
 namespace ferram4
 {
@@ -212,6 +213,8 @@ namespace ferram4
                 }
             }
         }
+
+        public FARControllableSurface() : base() { }
 
         //[KSPEvent(guiName = "Std. Ctrl Settings", guiActiveEditor = true, guiActive = false)]
         void CheckFieldVisibility()
@@ -764,5 +767,73 @@ namespace ferram4
             pos = resultVector;
             neg = -resultVector;
         }
+
+        protected FARControllableSurface(FARControllableSurface other, Dictionary<Guid, object> cache) : base(other, cache)
+        {
+            movableSection = other.movableSection;
+
+            flipAxis = other.flipAxis;
+
+            controlSurfacePivot = other.controlSurfacePivot;
+
+            ctrlSurfFrac = other.ctrlSurfFrac;
+            transformName = other.transformName;
+
+            MovableOrig = other.MovableOrig;
+            MovableOrigReady = other.MovableOrigReady;
+
+            showStdCtrl = other.showStdCtrl;
+            prevStdCtrl = other.prevStdCtrl;
+
+            pitchaxis = other.pitchaxis;
+
+            yawaxis = other.yawaxis;
+
+            rollaxis = other.rollaxis;
+
+            pitchaxisDueToAoA = other.pitchaxisDueToAoA;
+
+            brakeRudder = other.brakeRudder;
+
+            maxdeflect = other.maxdeflect;
+
+            showFlpCtrl = other.showFlpCtrl;
+            prevFlpCtrl = other.prevFlpCtrl;
+
+            isFlap = other.isFlap;
+            prevIsFlap = other.prevIsFlap;
+
+            isSpoiler = other.isSpoiler;
+            prevIsSpoiler = other.prevIsSpoiler;
+
+            flapDeflectionLevel = other.flapDeflectionLevel;
+
+            maxdeflectFlap = other.maxdeflectFlap;
+
+            PitchLocation = other.PitchLocation;
+            YawLocation = other.YawLocation;
+            RollLocation = other.RollLocation;
+            BrakeRudderLocation = other.BrakeRudderLocation;
+            BrakeRudderSide = other.BrakeRudderSide;
+            flapLocation = other.flapLocation;
+            spoilerLocation = other.spoilerLocation;
+
+            AoAsign = other.AoAsign;
+            AoAdesiredControl = other.AoAdesiredControl;
+            AoAdesiredFlap = other.AoAdesiredFlap;
+            AoAcurrentControl = other.AoAcurrentControl;
+            AoAcurrentFlap = other.AoAcurrentFlap;
+            AoAoffset = other.AoAoffset;
+
+            lastAoAoffset = other.lastAoAoffset;
+            deflectedNormal = other.deflectedNormal;
+
+            brake = other.brake;
+            justStarted = other.justStarted;
+
+            lastReferenceTransform = other.lastReferenceTransform;
+        }
+
+        public override object Clone(IFARCloneable other, Dictionary<Guid, object> cache) => new FARControllableSurface((FARControllableSurface)other, cache);
     }
 }

--- a/FerramAerospaceResearch/LEGACYferram4/FARPartModule.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARPartModule.cs
@@ -51,7 +51,7 @@ using FerramAerospaceResearch.FARUtils;
 
 namespace ferram4
 {
-    public class FARPartModule : PartModule
+    public class FARPartModule : FARCloneablePartModule
     {
         protected Callback OnVesselPartsChange;
         public List<Part> VesselPartList = null;
@@ -59,6 +59,8 @@ namespace ferram4
         private Collider[] partColliders = null;
 
         public Collider[] PartColliders { get { if(partColliders == null) TriggerPartColliderUpdate(); return partColliders; } protected set { partColliders = value; } }
+
+        public FARPartModule() : base() { }
 
         public void ForceOnVesselPartsChange()
         {
@@ -156,5 +158,17 @@ namespace ferram4
             VesselPartList = null;
             partColliders = null;
         }
+
+        protected FARPartModule(FARPartModule other, Dictionary<Guid, object> cache) : base(other, cache)
+        {
+            // Only do a shallow copy of KSP objects since they are not mutated here
+            VesselPartList = FARCloneHelper.ShallowCopy(other.VesselPartList);
+            VesselPartListCount = other.VesselPartListCount;
+            partColliders = FARCloneHelper.ShallowCopy(other.partColliders);
+
+            // For now keeping the callback null, no need to update vessel part list on a clone
+        }
+
+        public override object Clone(IFARCloneable other, Dictionary<Guid, object> cache) => new FARPartModule((FARPartModule)other, cache);
     }
 }

--- a/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
 Ferram Aerospace Research v0.15.9.5 "Lighthill"
 =========================
 Aerodynamics model for Kerbal Space Program
@@ -174,6 +174,8 @@ namespace ferram4
 
         public bool ready = false;
         bool massScaleReady = false;
+
+        public FARWingAerodynamicModel() : base() { }
 
         public void NUFAR_ClearExposedAreaFactor()
         {
@@ -1576,5 +1578,70 @@ namespace ferram4
             }
         }
 
+        protected FARWingAerodynamicModel(FARWingAerodynamicModel other, Dictionary<Guid, object> cache) : base(other, cache)
+        {
+            rawAoAmax = other.rawAoAmax;
+            AoAmax = other.AoAmax;
+            wingBaseMassMultiplier = other.wingBaseMassMultiplier;
+            curWingMass = other.curWingMass;
+            desiredMass = other.desiredMass;
+            baseMass = other.baseMass;
+            massMultiplier = other.massMultiplier;
+            oldMassMultiplier = other.oldMassMultiplier;
+            MAC = other.MAC;
+            MAC_actual = other.MAC_actual;
+            e = other.e;
+            nonSideAttach = other.nonSideAttach;
+            TaperRatio = other.TaperRatio;
+            stall = other.stall;
+            minStall = other.minStall;
+            piARe = other.piARe;
+            b_2 = other.b_2;
+            b_2_actual = other.b_2_actual;
+            MidChordSweep = other.MidChordSweep;
+            MidChordSweepSideways = other.MidChordSweepSideways;
+            cosSweepAngle = other.cosSweepAngle;
+            effective_b_2 = other.effective_b_2;
+            effective_MAC = other.effective_MAC;
+            effective_AR = other.effective_AR;
+            transformed_AR = other.transformed_AR;
+            // skip arrow pointers now
+            liftArrow = null;
+            dragArrow = null;
+            fieldsVisible = other.fieldsVisible;
+            dragForceWing = other.dragForceWing;
+            liftForceWing = other.liftForceWing;
+            rawLiftSlope = other.rawLiftSlope;
+            liftslope = other.liftslope;
+            finalLiftSlope = other.finalLiftSlope;
+            zeroLiftCdIncrement = other.zeroLiftCdIncrement;
+            criticalCl = other.criticalCl;
+            refAreaChildren = other.refAreaChildren;
+            AerodynamicCenter = other.AerodynamicCenter;
+            CurWingCentroid = other.CurWingCentroid;
+            ParallelInPlane = other.ParallelInPlane;
+            perp = other.perp;
+            liftDirection = other.liftDirection;
+            rootMidChordOffsetFromOrig = other.rootMidChordOffsetFromOrig;
+            localWingCentroid = other.localWingCentroid;
+            sweepPerpLocal = other.sweepPerpLocal;
+            sweepPerp2Local = other.sweepPerp2Local;
+            ParallelInPlaneLocal = other.ParallelInPlaneLocal;
+            wingInteraction = FARCloneHelper.Clone<FARWingInteraction>(other.wingInteraction, cache);
+            aeroModule = FARCloneHelper.Clone<FARAeroPartModule>(other.aeroModule, cache);
+            srfAttachNegative = other.srfAttachNegative;
+            parentWing = FARCloneHelper.Clone<FARWingAerodynamicModel>(other.parentWing, cache);
+            updateMassNextFrame = other.updateMassNextFrame;
+            ClIncrementFromRear = other.ClIncrementFromRear;
+            YmaxForce = other.YmaxForce;
+            XZmaxForce = other.XZmaxForce;
+            worldSpaceForce = other.worldSpaceForce;
+            NUFAR_areaExposedFactor = other.NUFAR_areaExposedFactor;
+            NUFAR_totalExposedAreaFactor = other.NUFAR_totalExposedAreaFactor;
+            ready = other.ready;
+            massScaleReady = other.massScaleReady;
+        }
+
+        public override object Clone(IFARCloneable other, Dictionary<Guid, object> cache) => new FARWingAerodynamicModel((FARWingAerodynamicModel)other, cache);
     }
 }

--- a/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Ferram Aerospace Research v0.15.9.5 "Lighthill"
 =========================
 Aerodynamics model for Kerbal Space Program
@@ -1503,56 +1503,59 @@ namespace ferram4
 
         private void UpdateAeroDisplay(Vector3 lift, Vector3 drag)
         {
-            if (PhysicsGlobals.AeroForceDisplay)
+            if (!isClone)
             {
-                if (liftArrow == null)
-                    liftArrow = ArrowPointer.Create(part_transform, localWingCentroid, lift, lift.magnitude * FARKSPAddonFlightScene.FARAeroForceDisplayScale, FerramAerospaceResearch.FARGUI.GUIColors.GetColor(0), true);
+                if (PhysicsGlobals.AeroForceDisplay)
+                {
+                    if (liftArrow == null)
+                        liftArrow = ArrowPointer.Create(part_transform, localWingCentroid, lift, lift.magnitude * FARKSPAddonFlightScene.FARAeroForceDisplayScale, FerramAerospaceResearch.FARGUI.GUIColors.GetColor(0), true);
+                    else
+                    {
+                        liftArrow.Direction = lift;
+                        liftArrow.Length = lift.magnitude * FARKSPAddonFlightScene.FARAeroForceDisplayScale;
+                    }
+
+                    if (dragArrow == null)
+                        dragArrow = ArrowPointer.Create(part_transform, localWingCentroid, drag, drag.magnitude * FARKSPAddonFlightScene.FARAeroForceDisplayScale, FerramAerospaceResearch.FARGUI.GUIColors.GetColor(1), true);
+                    else
+                    {
+                        dragArrow.Direction = drag;
+                        dragArrow.Length = drag.magnitude * FARKSPAddonFlightScene.FARAeroForceDisplayScale;
+                    }
+                }
                 else
                 {
-                    liftArrow.Direction = lift;
-                    liftArrow.Length = lift.magnitude * FARKSPAddonFlightScene.FARAeroForceDisplayScale;
+                    if ((object)liftArrow != null)
+                    {
+                        UnityEngine.Object.Destroy(liftArrow);
+                        liftArrow = null;
+                    }
+                    if ((object)dragArrow != null)
+                    {
+                        UnityEngine.Object.Destroy(dragArrow);
+                        dragArrow = null;
+                    }
                 }
 
-                if (dragArrow == null)
-                    dragArrow = ArrowPointer.Create(part_transform, localWingCentroid, drag, drag.magnitude * FARKSPAddonFlightScene.FARAeroForceDisplayScale, FerramAerospaceResearch.FARGUI.GUIColors.GetColor(1), true);
-                else
+                if (PhysicsGlobals.AeroDataDisplay)
                 {
-                    dragArrow.Direction = drag;
-                    dragArrow.Length = drag.magnitude * FARKSPAddonFlightScene.FARAeroForceDisplayScale;
-                }
-            }
-            else
-            {
-                if ((object)liftArrow != null)
-                {
-                    UnityEngine.Object.Destroy(liftArrow);
-                    liftArrow = null;
-                }
-                if ((object)dragArrow != null)
-                {
-                    UnityEngine.Object.Destroy(dragArrow);
-                    dragArrow = null;
-                }
-            }
+                    if (!fieldsVisible)
+                    {
+                        Fields["dragForceWing"].guiActive = true;
+                        Fields["liftForceWing"].guiActive = true;
+                        fieldsVisible = true;
+                    }
 
-            if (PhysicsGlobals.AeroDataDisplay)
-            {
-                if (!fieldsVisible)
-                {
-                    Fields["dragForceWing"].guiActive = true;
-                    Fields["liftForceWing"].guiActive = true;
-                    fieldsVisible = true;
+                    dragForceWing = drag.magnitude;
+                    liftForceWing = lift.magnitude;
+
                 }
-
-                dragForceWing = drag.magnitude;
-                liftForceWing = lift.magnitude;
-
-            }
-            else if (fieldsVisible)
-            {
-                Fields["dragForceWing"].guiActive = false;
-                Fields["liftForceWing"].guiActive = false;
-                fieldsVisible = false;
+                else if (fieldsVisible)
+                {
+                    Fields["dragForceWing"].guiActive = false;
+                    Fields["liftForceWing"].guiActive = false;
+                    fieldsVisible = false;
+                }
             }
 
         }

--- a/FerramAerospaceResearch/LEGACYferram4/FARWingInteraction.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARWingInteraction.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
 Ferram Aerospace Research v0.15.9.5 "Lighthill"
 =========================
 Aerodynamics model for Kerbal Space Program
@@ -663,7 +663,7 @@ namespace ferram4
                 FARWingAerodynamicModel wingModule = wingModules[i];
                 double wingInfluenceFactor = associatedInfluences[i] * directionalInfluence;
 
-                if (wingModule == null)
+                if (wingModule is null)
                 {
                     HandleNullPart(wingModules, associatedInfluences, i);
                     i--;


### PR DESCRIPTION
This can be used to ensure thread safety when calling simulation methods from multiple threads, mainly for Kerbal Wind Tunnel support.