### PR TITLE
Performance optimizations

### DIFF
--- a/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
@@ -100,6 +100,9 @@ namespace FerramAerospaceResearch.FARAeroComponents
         VehicleAerodynamics _vehicleAero;
         VesselIntakeRamDrag _vesselIntakeRamDrag;
 
+        // some internal variables
+        private Vector3 frameVel;
+
         protected override void OnStart()
         {
             FARLogger.Info("FARVesselAero on " + vessel.name + " reporting startup");
@@ -274,13 +277,14 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
             float pseudoKnudsenNumber = (float)(machNumber / (reynoldsNumber + machNumber));
 
+            frameVel = Krakensbane.GetFrameVelocityV3f();
 
             //if(_updateQueued)       //only happens if we have an voxelization scheduled, then we need to check for null
             for (int i = _currentAeroModules.Count - 1; i >= 0; i--)        //start from the top and come down to improve performance if it needs to remove anything
             {
                 if (_currentAeroModules[i] != null && _currentAeroModules[i].part != null && _currentAeroModules[i].part.partTransform != null)
                 {
-                    _currentAeroModules[i].UpdateVelocityAndAngVelocity(Krakensbane.GetFrameVelocityV3f());
+                    _currentAeroModules[i].UpdateVelocityAndAngVelocity(frameVel);
                 }
                 else
                 {

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
@@ -125,10 +125,13 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             //since we're sharing the button, we need these shenanigans now
             if (FARDebugAndSettings.FARDebugButtonStock && HighLogic.LoadedSceneIsFlight)
                 if (showGUI)
+                {
                     FARDebugAndSettings.FARDebugButtonStock.SetTrue(false);
+                }
                 else
+                {
                     FARDebugAndSettings.FARDebugButtonStock.SetFalse(false);
-
+                }
 
             _vessel = GetComponent<Vessel>();
             _vesselAero = GetComponent<FARVesselAero>();
@@ -142,19 +145,27 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             //boxStyle.padding = new RectOffset(4, 4, 4, 4);
 
             if (vesselFlightGUI.ContainsKey(_vessel))
+            {
                 vesselFlightGUI[_vessel] = this;
+            }
             else
+            {
                 vesselFlightGUI.Add(_vessel, this);
+            }
 
             this.enabled = true;
 
             if(FARDebugValues.useBlizzyToolbar)
+            {
                 GenerateBlizzyToolbarButton();
+            }
 
             activeFlightGUICount++;
 
             if(_vessel == FlightGlobals.ActiveVessel || FlightGlobals.ActiveVessel == null)
+            {
                 LoadConfigs();
+            }
 
             GameEvents.onShowUI.Add(ShowUI);
             GameEvents.onHideUI.Add(HideUI);
@@ -173,19 +184,30 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             _physicsCalcs = null;
 
             if(_flightDataGUI != null)
+            {
                 _flightDataGUI.SaveSettings();
+            }
+
             _flightDataGUI = null;
 
             if(_stabilityAugmentation != null)
+            {
                 _stabilityAugmentation.SaveAndDestroy();
+            }
+
             _stabilityAugmentation = null;
 
             if(_airSpeedGUI != null)
+            {
                 _airSpeedGUI.SaveSettings();
+            }
+
             _airSpeedGUI = null;
 
             if (_aeroVizGUI != null)
+            {
                 _aeroVizGUI.SaveSettings();
+            }
 
             _flightStatusGUI = null;
             settingsWindow = null;
@@ -196,7 +218,9 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             {
                 activeFlightGUICount = 0;
                 if (blizzyFlightGUIButton != null)
+                {
                     ClearBlizzyToolbarButton();
+                }
             }
 
             savedShowGUI = showGUI;
@@ -208,13 +232,24 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             {
                 SaveConfigs();
                 if(_airSpeedGUI != null)
+                {
                     _airSpeedGUI.SaveSettings();
-                if(_stabilityAugmentation != null)
+                }
+
+                if (_stabilityAugmentation != null)
+                {
                     _stabilityAugmentation.SaveSettings();
-                if(_flightDataGUI != null)
+                }
+
+                if (_flightDataGUI != null)
+                {
                     _flightDataGUI.SaveSettings();
-                if(_aeroVizGUI != null)
+                }
+
+                if (_aeroVizGUI != null)
+                {
                     _aeroVizGUI.SaveSettings();
+                }
             }
         }
         public static void SaveActiveData()
@@ -230,7 +265,10 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         //Receives message from FARVesselAero through _vessel on the recalc being completed
         public void UpdateAeroModules(List<FARAeroPartModule> newAeroModules, List<FARWingAerodynamicModel> legacyWingModels)
         {
-            _physicsCalcs.UpdateAeroModules(newAeroModules, legacyWingModels);
+            if (showGUI)
+            {
+                _physicsCalcs.UpdateAeroModules(newAeroModules, legacyWingModels);
+            }
         }
 
         //Receives a message from any FARWingAerodynamicModel or FARAeroPartModule that has failed to update the GUI
@@ -243,8 +281,10 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         #region PhysicsAndOrientationBlock
         void FixedUpdate()
         {
-            if (_physicsCalcs == null)
+            if (_physicsCalcs == null || !showGUI )
+            {
                 return;
+            }
 
             infoParameters = _physicsCalcs.UpdatePhysicsParameters();
 
@@ -271,9 +311,13 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         {
             //OnGUIAppLauncherReady();
             if (_airSpeedGUI != null)
+            {
                 _airSpeedGUI.ChangeSurfVelocity();
+            }
             else if (_vessel != null)
+            {
                 _airSpeedGUI = new AirspeedSettingsGUI(_vessel);
+            }
         }
 
         #region GUI Functions

--- a/FerramAerospaceResearch/FARUtils/FARLogger.cs
+++ b/FerramAerospaceResearch/FARUtils/FARLogger.cs
@@ -47,12 +47,17 @@ Copyright 2018, Daumantas Kavolis, aka dkavolis
 
 using System;
 using System.Diagnostics;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace FerramAerospaceResearch.FARUtils
 {
     public static class FARLogger
     {
+
+        private static Dictionary<string, Stopwatch> alltimers = new Dictionary<string, Stopwatch>();
+        private static Stopwatch myWatch = null;
+
 
         public static string defaultTag = $"[FAR {FARVersion.String}]";
 
@@ -102,28 +107,52 @@ namespace FerramAerospaceResearch.FARUtils
 
         #region Info
         [Conditional("DEBUG"), Conditional("INFO")]
-        public static void Info(object message) => UnityEngine.Debug.Log(Tag + " " + message);
+        public static void Info(object message)
+        {
+            UnityEngine.Debug.Log(Tag + " " + message);
+        }
 
         [Conditional("DEBUG"), Conditional("INFO")]
-        public static void Info(object message, UnityEngine.Object context) => UnityEngine.Debug.Log(Tag + " " + message, context);
+        public static void Info(object message, UnityEngine.Object context)
+        {
+            UnityEngine.Debug.Log(Tag + " " + message, context);
+        }
 
         [Conditional("DEBUG"), Conditional("INFO")]
-        public static void InfoFormat(string format, params object[] args) => UnityEngine.Debug.LogFormat(Tag + " " + format, args);
+        public static void InfoFormat(string format, params object[] args)
+        {
+            UnityEngine.Debug.LogFormat(Tag + " " + format, args);
+        }
 
         [Conditional("DEBUG"), Conditional("INFO")]
-        public static void InfoFormat(UnityEngine.Object context, string format, params object[] args) => UnityEngine.Debug.LogFormat(context, Tag + " " + format, args);
+        public static void InfoFormat(UnityEngine.Object context, string format, params object[] args)
+        {
+            UnityEngine.Debug.LogFormat(context, Tag + " " + format, args);
+        }
 
         [Conditional("DEBUG"), Conditional("INFO")]
-        public static void InfoWithCaller(object message) => UnityEngine.Debug.Log(Tag + " " + GetCallerInfo() + " - " + message);
+        public static void InfoWithCaller(object message)
+        {
+            UnityEngine.Debug.Log(Tag + " " + GetCallerInfo() + " - " + message);
+        }
 
         [Conditional("DEBUG"), Conditional("INFO")]
-        public static void InfoWithCaller(object message, UnityEngine.Object context) => UnityEngine.Debug.Log(Tag + " " + GetCallerInfo() + " - " + message, context);
+        public static void InfoWithCaller(object message, UnityEngine.Object context)
+        {
+            UnityEngine.Debug.Log(Tag + " " + GetCallerInfo() + " - " + message, context);
+        }
 
         [Conditional("DEBUG"), Conditional("INFO")]
-        public static void InfoFormatWithCaller(string format, params object[] args) => UnityEngine.Debug.LogFormat(Tag + " " + GetCallerInfo() + " - " + format, args);
+        public static void InfoFormatWithCaller(string format, params object[] args)
+        {
+            UnityEngine.Debug.LogFormat(Tag + " " + GetCallerInfo() + " - " + format, args);
+        }
 
         [Conditional("DEBUG"), Conditional("INFO")]
-        public static void InfoFormatWithCaller(UnityEngine.Object context, string format, params object[] args) => UnityEngine.Debug.LogFormat(context, Tag + " " + GetCallerInfo() + " - " + format, args);
+        public static void InfoFormatWithCaller(UnityEngine.Object context, string format, params object[] args)
+        {
+            UnityEngine.Debug.LogFormat(context, Tag + " " + GetCallerInfo() + " - " + format, args);
+        }
         #endregion // Info
 
         #region Debug
@@ -247,6 +276,61 @@ namespace FerramAerospaceResearch.FARUtils
             UnityEngine.Debug.LogException(exception, context);
         }
         #endregion // Exception
+
+        #region Performace
+        internal static void PerfStart(string id = "default")
+        {
+            myWatch = new Stopwatch();
+
+            if (alltimers.ContainsKey(id))
+            {
+                alltimers.Remove(id);
+            }
+            alltimers.Add(id, myWatch);
+            myWatch.Start();
+        }
+
+        /// <summary>
+        /// resets the Stopwatchtimer with the (string)id and prints the result.
+        /// </summary>
+        /// <param name="id"></param>
+        internal static void PerfStop(string id = "default")
+        {
+            if (alltimers.TryGetValue(id, out myWatch))
+            {
+                myWatch.Stop();
+                FARLogger.Info("Stopwatch: \"" + id + "\" elapsed time: " + myWatch.Elapsed);
+                myWatch.Reset();
+                alltimers.Remove(id);
+            }
+        }
+
+        /// <summary>
+        /// Pauses the timer with the id
+        /// </summary>
+        /// <param name="id"></param>
+        internal static void PerfPause(string id = "default")
+        {
+            if (alltimers.TryGetValue(id, out myWatch))
+            {
+                myWatch.Stop();
+            }
+        }
+
+        /// <summary>
+        /// resumes the timer
+        /// </summary>
+        /// <param name="id"></param>
+        internal static void PerfContinue(string id = "default")
+        {
+            if (alltimers.TryGetValue(id, out myWatch))
+            {
+                myWatch.Start();
+            }
+        }
+
+        #endregion
+
 
         //http://geekswithblogs.net/BlackRabbitCoder/archive/2013/07/25/c.net-little-wonders-getting-caller-information.aspx
         private static string GetCallerInfo()

--- a/FerramAerospaceResearch/FerramAerospaceResearch.csproj
+++ b/FerramAerospaceResearch/FerramAerospaceResearch.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -37,30 +37,30 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\KSP Assemblies\1.5.1\Assembly-CSharp.dll</HintPath>
+    <Reference Include="Assembly-CSharp">
+      <HintPath>..\..\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="KSPAssets, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\KSP Assemblies\1.5.1\KSPAssets.dll</HintPath>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\..\Kerbal Space Program\KSP_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="ModularFlightIntegrator, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\KSP Assemblies\1.5.1\ModularFlightIntegrator.dll</HintPath>
+    <Reference Include="ModularFlightIntegrator">
+      <HintPath>..\..\Kerbal Space Program\GameData\ModularFlightIntegrator\ModularFlightIntegrator.dll</HintPath>
+      <Private>False</Private>
     </Reference>
     <Reference Include="Scale_Redist, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\GameData\FerramAerospaceResearch\Plugins\Scale_Redist.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\KSP Assemblies\1.5.1\UnityEngine.dll</HintPath>
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\Kerbal Space Program\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <Private>False</Private>
     </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\KSP Assemblies\1.5.1\UnityEngine.UI.dll</HintPath>
+    <Reference Include="UnityEngine.UI">
+      <HintPath>..\..\Kerbal Space Program\KSP_Data\Managed\UnityEngine.UI.dll</HintPath>
+      <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This is a first round of small improvements to reduce memory garbage created by FAR. 
1. Most code except the voxelazation is cleaned up
2. GUI Values are only calculated when the GUI is shown
3. added a FARLogger.PerfStart(string). .PerfStop(string), .PerfCont(string),  .PerfPause(string)  

functions
You create a new Stopwatch with PerfStart (id string), and you can pause or continue or just end it. When ended it will print out the time elaped.