### PR TITLE
Add ReStock bug hotfix

### DIFF
--- a/FerramAerospaceResearch/FARReStockFix.cfg
+++ b/FerramAerospaceResearch/FARReStockFix.cfg
@@ -1,0 +1,70 @@
+@PART[rapierEngine]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}
+@PART[restock-engine-boar]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}
+@PART[restock-engine-torch]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}
+@PART[liquidEngineMini_v2]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}
+@PART[SSME]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}
+@PART[Size2LFB]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}
+@PART[liquidEngine1-2]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}
+@PART[liquidEngine2-2_v2]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}
+@PART[Size3AdvancedEngine]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}
+@PART[Size3EngineCluster]:AFTER[FerramAerospaceResearch]
+{
+	@MODULE[GeometryPartModule]
+	{
+		%forceUseColliders = True
+	}
+}


### PR DESCRIPTION
Due to way in which some engines' meshes are created in the ReStock and ReStockPlus mod, FAR treats these engines as being much larger, for aerodynamics calculations, than they really are.

This MM config file forces FAR to use colliders on these engines.