### PR TITLE
Fix German localization formatting

### DIFF
--- a/GameData/FerramAerospaceResearch/Localization/Localization_de-de.cfg
+++ b/GameData/FerramAerospaceResearch/Localization/Localization_de-de.cfg
@@ -1,423 +1,429 @@
-﻿FARGUIOKButton = OK
-
-FARCompatCheckTitle = Inkompatible Mods erkannt
-FARCompatCheckWarning = Einige installierte Mods könnten inkompatibel mit dieser Version von Kerbal Space Program sein. Manches könnte nicht funktionieren oder abgeschaltet sein. Bitte überprüfe nach Updates für die gelisteten Mods.
-FARCompatCheckKSP = \n\nDiese Mods sind inkompatibel mit KSP <<1>>.<<2>>.<<3>>:\n\n
-FARCompatCheckUnity = \n\nDiese Mods sind inkompatibel mit Unity <<1>>:\n\n
-
-FARFlightLogAeroFailure = [<<1>>] <<2>> versagte wegen aerodynamischer Belastung.
-
-FARDesignConcernStabTitle = Gefährt ist aerodynamisch instabil!
-FARDesignConcernDesc = Der aerodynamische Mittelpunkt liegt vor dem Schwerpunkt; das Gefährt braucht ausreichend Schubvektorsteuerung um Vorwärtsflug beizubehalten.
-
-FARDesignConcernAreaRuleTitle = Hoher transonischer- / Überschallwiderstand!
-FARDesignConcernAreaRuleDesc = Die Querschnittsflächenverteilung ist nicht glatt genug und/oder enthält sehr große plötzliche Schwankungen der Fläche.
-
-FARAbbrevCl = Cl
-FARAbbrevCd = Cd
-FARAbbrevCm = Cm
-FARAbbrevL_D = L/D
-FARAbbrevAoA = AoA
-FARAbbrevMach = Mach
-
-FARUnitM = m
-FARUnitMSq = m²
-FARUnitMPerSec = m/s
-FARUnitMPerSecSq = m/s²
-FARUnitKgMSq = kg * m²
-FARUnitDeg = °
-FARUnitInvSec = s⁻¹
-FARUnitInvSecSq = s⁻²
-FARUnitInvMSec = (m * s)⁻¹
-
-FARUnitKPa = kPa
-FARUnitKN = kN
-FARUnitInvHr = hr⁻¹
-FARUnitPercent = %
-FARUnitSpecPower = W/kg
-FARUnitHr = hr
-FARUnitkM = km
-FARUnitBC = kg/m²
-
-FAREditorTitle = FAR Analyse
-
-FAREditorModeStatic = Statische Analyse
-FAREditorModeDataStab = Daten- & Stabilitätsvorhersagen
-FAREditorModeDerivSim = Stab.vorhersg. Simulation
-FAREditorModeTrans = Transonisches Design
-
-FARFlapSetting0 = 0 (Auf)
-FARFlapSetting1 = 1 (Init. Steigen)
-FARFlapSetting2 = 2 (Start)
-FARFlapSetting3 = 3 (Landung)
-
-FARGearToggleLower = Fahrwerk ausfahren
-FARGearToggleRaise = Fahrwerk einfahren
-
-FARVelIndHide = Verstecke Tempo-Anzeige
-FARVelIndShow = Zeige Tempo-Anzeige
-
-FARDebugVoxels = Debug Voxels anzeigen
-
-FAREditorTitleTransonic = Transonische Flächenanalyse
-FAREditorTransMaxArea = Maximale Querschnittsfläche:\u0020
-FAREditorTransMach1DragArea = Mach 1 Wellenwiderstandsfläche:\u0020
-FAREditorTransCritMach = Kritische Mach-Zahl:\u0020
-FAREditorTransMinDragExp1 = Minimaler Wellenwiderstand wird durch eine glatte,\n\rminimale Krümmungs-Querschnittsflächen-Kurve erreicht,\n\r unter der Berücksichtigung des Einlass->Triebwerk–Rohres.
-FAREditorTransMinDragExp2 = Minimiere Krümmung um Wellenwiderstand zu minimieren.
-FAREditorTransAreaCurve = Zeige Kurve: Querschnittsfläche (green)
-FAREditorTransCurvCurve = Zeige Kurve: Krümmung-Querschnittsfläche (yellow)
-FAREditorTransPresCurve = Zeige Kurve: ⌀ des Druck-Koeffizienten (blue)
-
-FAREditorStabDerivFlightCond = Flugumstände:
-FAREditorStabDerivPlanet = Planet:
-FAREditorStabDerivAlt = Höhe (km):
-FAREditorStabDerivMach = Mach-Zahl:
-FAREditorStabDerivFlap = Flap Setting:
-FAREditorStabDerivSpoiler = Spoiler:
-FAREditorStabDerivSDeploy = Ausgefahren
-FAREditorStabDerivSRetract = Eingefahren
-
-FAREditorStabDerivCalcButton = Berechne Stabilitätswerte
-FAREditorStabDerivSaveButton = Stabilitätswerte speichern
-FAREditorStabDerivLoopButton = Run Export Sweep
-FAREditorStabDerivError = Fehler!
-FAREditorStabDerivErrorExp = Höhe war über der Atmosphäre
-FAREditorStabDerivSaveError = Fehler!
-FAREditorStabDerivSaveErrorExp = Unable to export stability derivatives. You may need to delete previous exported values.
-FAREditorStabDerivLoopDone = Calculation loop complete
-FAREditorStabDerivLoopDoneExp = The stability derivatives export loop calculated and exported <<1>> solution result(s).
-
-FAREditorStabDerivAirProp = Flugzeug-Eigenschaften
-FAREditorStabDerivMoI = Trägheitsmoment
-FAREditorStabDerivPoI = Trägheitsprodukt
-FAREditorStabDerivLvlFl = Level-Flug
-
-// TODO: FAREditorStabDeriv localization
-FAREditorStabDerivRefArea = Ref Area:\u0020
-FAREditorStabDerivScaledChord = Scaled Chord:\u0020
-FAREditorStabDerivScaledSpan = Scaled Span:\u0020
-
-FAREditorStabDerivIxx = Ixx:\u0020
-FAREditorStabDerivIyy = Iyy:\u0020
-FAREditorStabDerivIzz = Izz:\u0020
-FAREditorStabDerivIxy = Ixy:\u0020
-FAREditorStabDerivIyz = Iyz:\u0020
-FAREditorStabDerivIxz = Ixz:\u0020
-
-FAREditorStabDerivIxxExp = Trägheit um X-Achse durch Rotation um X-Achse
-FAREditorStabDerivIyyExp = Trägheit um Y-Achse durch Rotation um Y-Achse
-FAREditorStabDerivIzzExp = Trägheit um Z-Achse durch Rotation um Z-Achse
-FAREditorStabDerivIxyExp = Trägheit um X-Achse durch Rotation um Y-Achse; ist gleich der Trägheit um Y-Achse durch Rotation um X-Achse
-FAREditorStabDerivIyzExp = Trägheit um Y-Achse durch Rotation um Z-Achse; ist gleich der Trägheit um Z-Achse durch Rotation um Y-Achse
-FAREditorStabDerivIxzExp = Trägheit um X-Achse durch Rotation um Z-Achse; ist gleich der Trägheit um Z-Achse durch Rotation um X-Achse
-
-FAREditorStabDerivu0 = u0:\u0020
-FAREditorStabDerivu0Exp = Lufttempo basierend auf dieser Mach-Zahl und Temperatur.
-FAREditorStabDerivClExp = Benötigter Liftkoeffizient bei diesem Gewicht, Tempo und Luftdruck.
-FAREditorStabDerivCdExp = Resultierender Luftwiderstandsfaktor bei diesem Gewicht, Tempo und Luftdruck.
-FAREditorStabDerivAoAExp = Benötigter Anstellwinkel für die benötigte Kraft an Lift.
-
-FAREditorLongDeriv = Längs-Ableitungen
-FAREditorDownVelDeriv = Abwärts-Tempo-Ableitungen
-FAREditorFwdVelDeriv = Vorwärts-Tempo-Ableitungen
-FAREditorPitchRateDeriv = Nickraten-Ableitungen
-FAREditorPitchCtrlDeriv = Nickkontroll-Ableitungen
-
-FAREditorZw = Zw:\u0020
-FAREditorZu = Zu:\u0020
-FAREditorZq = Zq:\u0020
-FAREditorZDeltae = Zδe:\u0020
-
-FAREditorXw = Xw:\u0020
-FAREditorXu = Xu:\u0020
-FAREditorXq = Xq:\u0020
-FAREditorXDeltae = Xδe:\u0020
-
-FAREditorMw = Mw:\u0020
-FAREditorMu = Mu:\u0020
-FAREditorMq = Mq:\u0020
-FAREditorMDeltae = Mδe:\u0020
-
-FAREditorZwExp = Änderung in Z-gerichteter Beschleunigung hinsichtlich zum Tempo in Z-Richtung; sollte negativ sein.
-FAREditorZuExp = Änderung in Z-gerichteter Beschleunigung hinsichtlich zum Tempo in X-Richtung; sollte negativ sein.
-FAREditorZqExp = Änderung in Z-gerichteter Beschleunigung hinsichtlich zur Hochzieh-Rate; Vorzeichen unwichtig.
-FAREditorZDeltaeExp = Änderung in Z-gerichteter Beschleunigung hinsichtlich zur Nick-Steuerung-Eingabe; Vorzeichen unwichtig.
-
-FAREditorXwExp = Änderung in X-gerichteter Beschleunigung hinsichtlich zum Tempo in Z-Richtung; Vorzeichen unwichtig.
-FAREditorXuExp = Änderung in X-gerichteter Beschleunigung hinsichtlich zum Tempo in X-Richtung; sollte negativ sein.
-FAREditorXqExp = Änderung in X-gerichteter Beschleunigung hinsichtlich zur Hochzieh-Rate; Vorzeichen unwichtig.
-FAREditorXDeltaeExp = Änderung in X-gerichteter Beschleunigung hinsichtlich zur Nick-Steuerung-Eingabe; Vorzeichen unwichtig.
-
-FAREditorMwExp = Änderung der Hochzieh-Winkelbeschleunigung hinsichtlich zum Tempo in Z-Richtung; sollte negativ sein.
-FAREditorMuExp = Änderung der Hochzieh-Winkelbeschleunigung hinsichtlich zum Tempo in X-Richtung; Vorzeichen unwichtig.
-FAREditorMqExp = Änderung der Hochzieh-Winkelbeschleunigung hinsichtlich zur Hochzieh-Rate; sollte negativ sein.
-FAREditorMDeltaeExp = Änderung der Hochzieh-Winkelbeschleunigung hinsichtlich zur Nick-Steuerung-Eingabe; sollte positiv sein.
-
-FAREditorLatDeriv = Querableitungen
-FAREditorSideslipDeriv = Seitengleitflug-Ableitungen
-FAREditorRollRateDeriv = Rollraten-Ableitungen
-FAREditorYawRateDeriv = Gierraten-Ableitungen
-
-FAREditorYβ = Yβ:\u0020
-FAREditorYp = Yp:\u0020
-FAREditorYr = Yr:\u0020
-
-FAREditorLβ = Lβ:\u0020
-FAREditorLp = Lp:\u0020
-FAREditorLr = Lr:\u0020
-
-FAREditorNβ = Nβ:\u0020
-FAREditorNp = Np:\u0020
-FAREditorNr = Nr:\u0020
-
-FAREditorYβExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zum Schiebewinkel β; sollte negativ sein.
-FAREditorYpExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zur Rechts-Roll-Rate; Vorzeichen unwichtig.
-FAREditorYrExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zur Rechts-Gier-Rate; sollte positiv sein.
-
-FAREditorYβExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zum Schiebewinkel β; sollte negativ sein.
-FAREditorYpExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zur Rechts-Roll-Rate; Vorzeichen unwichtig.
-FAREditorYrExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zur Rechts-Gier-Rate; sollte positiv sein.
-
-FAREditorLβExp = Änderung in Rechts-Roll-Winkelbeschleunigung hinsichtlich zum Schiebewinkel β; sollte negativ sein.
-FAREditorLpExp = Änderung in Rechts-Roll-Winkelbeschleunigung hinsichtlich zur Rechts-Roll-Rate; sollte negativ sein.
-FAREditorLrExp = Änderung in Rechts-Roll-Winkelbeschleunigung hinsichtlich zur Rechts-Gier-Rate; sollte positiv sein.
-
-FAREditorNβExp = Änderung in Rechts-Gier-Winkelbeschleunigung hinsichtlich zum Schiebewinkel β; sollte positiv sein.
-FAREditorNpExp = Änderung in Rechts-Gier-Winkelbeschleunigung hinsichtlich zur Rechts-Roll-Rate; Vorzeichen unwichtig.
-FAREditorNrExp = Änderung in Rechts-Gier-Winkelbeschleunigung hinsichtlich zur Rechts-Gier-Rate; sollte negativ sein.
-
-FAREditorSimModeLong = Längs-Sim
-FAREditorSimModeLat = Quer-Sim
-FAREditorSimGraphTime = Zeit (s)
-FAREditorSimGraphParams = Parameter
-
-FAREditorSimInit = Init
-FAREditorSimEndTime = EndZeit:
-FAREditorSimTimestep = dt:
-FAREditorSimRunButton = Starte Simulation
-
-FAREditorStaticGraphAoA = Anstellwinkel, Winkel
-FAREditorStaticGraphMach = Mach-Zahl
-FAREditorStaticGraphCoeff = Cl\nCd\nCm\nL/D / 10
-
-// Is there a German translation for Sweep?
-FAREditorStaticMachSweep = Mach-Zahl-Analyse
-FAREditorStaticAoASweep = Anstellwinkel-Analyse
-FAREditorStaticSwitchAoA = Schalte zu AoA Sweep
-FAREditorStaticSwitchMach = Schalte zu Mach Sweep
-
-FAREditorStaticPitchSetting = Pitch-Einstellung:
-
-FAREditorStaticGraphLowLim = Untere:
-FAREditorStaticGraphUpLim = Obere:
-FAREditorStaticGraphPtCount = Num Pts:
-
-FAREditorStaticSweepMach = Sweep Mach
-FAREditorStaticSweepAoA = Sweep AoA
-
-FARFlightAeroVizTitle = Aero-Visualisierungs-Einstellungen
-
-FARFlightAeroVizTintCl = Färbung Cl
-FARFlightAeroVizTintClSatWing = Vollfärbung Cl (Flügel):
-FARFlightAeroVizTintClSatBody = Vollfärbung Cl (Körper):
-
-FARFlightAeroVizTintCd = Färbung Cd
-FARFlightAeroVizTintCdSatWing = Vollfärbung Cd (Flügel):
-FARFlightAeroVizTintCdSatBody = Vollfärbung Cd (Körper):
-
-FARFlightAeroVizTintStall = Färbung Strmg.abriss
-FARFlightAeroVizTintStallSat = Vollfärbung Strmg. abgerissen %:
-
-FARFlightAeroVizToggleArrows = Zeige Aero Pfeile
-
-FARFlightAirspeedGroundspeed = Surface
-FARFlightAirspeedIndicated = IAS
-FARFlightAirspeedEquivalent = EAS
-
-FARFlightInternalAirspeedGroundspeed = Srf.:\u0020
-FARFlightInternalAirspeedIndicated = IAS:\u0020
-FARFlightInternalAirspeedEquivalent = EAS:\u0020
-FARFlightInternalAirspeedMach = Mach:\u0020
-
-FARFlightAirspeedMeterPerSec = m/s
-FARFlightAirspeedKnots = Knoten
-FARFlightAirspeedMPH = mph
-FARFlightAirspeedKMH = km/h
-
-FARFlightAirspeedLabel = Wähle Bodengeschwindigkeit-Einstellung
-
-FARFlightDataTitle = FAR Flugdaten
-FARFlightDataOptionLabel = Anzuzeigende Flugdaten
-
-FARFlightDataOption0 = PYR Angles
-FARFlightDataOption1 = AoA + Sideslip
-FARFlightDataOption2 = Dyn Druck
-FARFlightDataOption3 = Aero Kräfte
-FARFlightDataOption4 = Coeffs + Ref Area
-FARFlightDataOption5 = L/D and V*L/D
-FARFlightDataOption6 = Motor + Ansauger
-FARFlightDataOption7 = Reichweite + Ausdauer
-FARFlightDataOption8 = BC und Term Tempo
-
-FARFlightData0 = Nickwinkel: \n\rRichtung: \n\rRollwinkel:
-FARFlightData1 = Anstellwinkel: \n\rSchiebewinkel:
-FARFlightData2 = Dyn Druck:
-FARFlightData3 = Lift: \n\rWiderstand: \n\rSeitenkraft:
-FARFlightData4 = Cl: \n\rCd: \n\rCy: \n\rRef Fläche:
-FARFlightData5 = L/D: \n\rV*L/D:
-// TODO
-FARFlightData6 = Treibstoff-Teil: \n\rTSFC: \n\rAir Req Met: \n\rSpec. Excess Pwr:
-FARFlightData7 = Est. Ausdauer: \n\rEst. Reichweite:
-FARFlightData8 = BC: \n\rAbbruch V:
-
-// English abbreviations are fine in German
-FARFlightGUIWindowSelect0 = Flt Data
-FARFlightGUIWindowSelect1 = Stab Aug
-FARFlightGUIWindowSelect2 = Lufttempo
-FARFlightGUIWindowSelect3 = Aero Viz
-
-FARFlightGUIReynolds = Reynolds: ｢0:E2｣
-FARFlightGUIAtmDens = Atm Dichte:\u0020
-FARFlightGUIFltDataBtn = Flt Daten
-FARFlightGUIFltSettings = Flt Einstellungen
-FARFlightGUIFltAssistance = Flughilfe Einstellungen:
-
-FARFlightSettingsTitle = FAR Einstellungen
-FARFlightSettingsLabel = Jetzige Gruppe:
-
-FARFlightStatusLabel = Flugstatus
-FARFlightStatus0 = Nominal
-FARFlightStatus1 = Strömungsabriss
-FARFlightStatus2 = Sackflug
-FARFlightStatus3 = Seitengleitflug
-FARFlightStatus4 = Hoher dyn. Druck
-FARFlightStatus5 = Aerodyn. Versagen
-
-FARFlightStabAugLabel0 = Roll
-FARFlightStabAugLabel1 = Gier
-FARFlightStabAugLabel2 = Nick
-FARFlightStabAugLabel3 = AoA
-FARFlightStabAugLabel4 = DPCR
-
-FARFlightStabAugLabelLong0 = Roll System
-FARFlightStabAugLabelLong1 = Gier System
-FARFlightStabAugLabelLong2 = Nick System
-FARFlightStabAugLabelLong3 = AoA Limiter
-FARFlightStabAugLabelLong4 = Dynamic Pressure Control Reduction
-
-FARFlightStabLabel = Kontrollsystemjustierung
-FARFlightStabPropGain = Proportionale Verstärkung:
-FARFlightStabDerivGain = Abgeleitete Verstärkung:
-FARFlightStabIntGain = Integrale Verstärkung:
-FARFlightStabAoALow = Min AoA Lim:
-FARFlightStabAoAHigh = Max AoA Lim:
-FARFlightStabOffset = Gewünschter Punkt:
-FARFlightStabQScaling = Dyn Druck für Kontrollskalierung:
-
-FARActionSpoilers = Spoiler
-FARActionIncreaseFlap = Erhöhe Klappenauslenkung
-FARActionDecreaseFlap = Verringere Klappenauslenkung
-FARActionDefaultLabel = Standard Action Group Belegungen
-
-FARCtrlSurfStdTitle = Std. Ctrl
-FARCtrlSurfStdText = Einstellungen
-FARCtrlSurfPitch = Nick %
-FARCtrlSurfYaw = Gier %
-FARCtrlSurfRoll = Roll %
-FARCtrlSurfAoA = AoA %
-FARCtrlSurfBrakeRudder = BremsRuder %
-FARCtrlSurfCtrlDeflect = Ctrl Aslnk
-
-FARCtrlSurfFlapSpoiler = Klp/Splr
-FARCtrlSurfFlap = Klappe
-FARCtrlSurfSpoiler = Spoiler
-FARCtrlSurfFlapActive = Aktiv
-FARCtrlSurfFlapInActive = Inaktiv
-FARCtrlSurfFlapSetting = Klappen Einst.
-FARCtrlSurfFlapDeflect = Klp/Splr Aslnk
-
-FARCtrlActionSpoiler = Aktiviere Spoiler
-FARCtrlActionIncFlap = Erhöhe Klappenauslenkung
-FARCtrlActionDecFlap = Verringere Klappenauslenkung
-FARCtrlEventIncFlap = Mehr auslenken
-FARCtrlEventDecFlap = Weniger auslenken
-
-FARWingMassStrength = Gewicht-Kraft Multiplikator %
-FARWingStalled = Stalled %
-
-RCLMatNylon = Nylon
-
-RCLStatusStowed = GEPACKT
-RCLStatusPreDep = TEIL OFFEN
-RCLStatusDep = OFFEN
-RCLStatusCut = GESCHNITTEN
-
-RCLSettingMinPres = Min Druck
-RCLSettingAlt = Höhe
-RCLStatusSpare = Vfg. Schirme
-RCLStatusChuteTemp = Schirm Temp
-RCLTempUnit = °C
-RCLStatusMaxTemp = Max Temp
-
-RCLEventDeploy = Schirm öffnen
-RCLEventCut = Schirm abschneiden
-RCLEventDisarm = Schirm deaktivieren
-RCLEventRepack = Schirm packen
-RCLEventToggleInfo = Info ein/aus
-
-RCLModuleTitle = RealChute
-
-RCLModuleInfo0 = <b>Gewicht Gehäuse</b>: <<1>>\n
-RCLModuleInfo1 = <b>Vfg. Schirme</b>: <<1>>\n
-RCLModuleInfo2 = <b>Auto Schnitttmepo</b>: <<1>>m/s\n
-RCLModuleInfo3 = <b>Fallschirm Material</b>: <<1>>
-RCLModuleInfo4 = <b>Drag Koeffizient</b>: <<1>>\n
-RCLModuleInfo5 = <b>Max Schirm Temperatur</b>: <<1>>°C\n
-RCLModuleInfo6 = <b>Durchmesser teilgeöffnet</b>: <<1>>m\n
-RCLModuleInfo7 = <b>Durchmesser geöffnet</b>: <<1>>m\n
-RCLModuleInfo8 = <b>Min Druck für Öffnung</b>: <<1>>atm\n
-RCLModuleInfo9 = <b>Einsatzhöhe</b>: <<1>>m\n
-RCLModuleInfo10 = <b>Tempo bei Teilöffnung</b>: <<1>>s\n
-RCLModuleInfo11 = <b>Tempo bei Öffnung</b>: <<1>>s\n
-
-RCLRepackErrorMessage = Nur ein Ingenieur mit Level 1 aufwärts kann einen Fallschirm packen
-RCLDestroyMessage = <color=orange>[RealChute]: Fallschirm von <<1>>wurde durch Aerokräfte und Hitze zerstört.</color>
-
-RCLGUITitle = RealChute Infofenster
-RCLGUI0 = Bauteil Name: <<1>>
-RCLGUI1 = Symmetrie-Gegenstücke: <<1>>
-RCLGUI2 = Bauteil Gewicht: <<1>>t
-
-RCLGUI3 = Allgemein:
-
-RCLGUI4 = Auto Schnitttempo: <<1>>m/s
-RCLGUI5 = Vfg. Schirme: <<1>>
-
-RCLGUI6 = Hauptfallschirm:
-RCLGUI7 = Material: <<1>>
-RCLGUI8 = Drag Koeffizient <<1>>
-RCLGUI9 = Durchmesser teilgeöffnet: <<1>>m\nArea: <<2>>m²
-RCLGUI10 = Durchmesser geöffnet: <<1>>m\nFläche: <<2>>m²
-
-RCLGUISafe = Einsatzsicherheit: sicher
-RCLGUIRisky = Einsatzsicherheit: riskant
-RCLGUIDang = Einsatzsicherheit: gefährlich
-
-RCLGUI11 = max Schirm Temperatur: <<1>>°C
-RCLGUI12 = momentane Schirm Temperatur: <<1>>°C
-
-RCLGUI13 = Teilöffnungs-Druck: <<1>>Atm
-RCLGUI14 = Öffnungs-Höhe: <<1>>m
-
-RCLGUI15 = Dauer Teilöffnung: <<1>>s
-RCLGUI16 = Dauer Öffnung: <<1>>s
-
-RCLGUICopy = Zu anderen Schirmen kopieren
-RCLGUIClose = Schließen
-
-RCLFailDeploy = Fallschirmöffnung fehlgeschlagen.
-RCLFailShielded = Grund: Fallschirm ist im Windschatten.
-RCLFailGround = Grund: gestoppt & gelandet.
-RCLFailPres = Grund: im Weltraum.
-RCLFailOther = Grund: zu hoch.
+Localization
+{
+    de-de
+    {
+        FARGUIOKButton = OK
+
+        FARCompatCheckTitle = Inkompatible Mods erkannt
+        FARCompatCheckWarning = Einige installierte Mods könnten inkompatibel mit dieser Version von Kerbal Space Program sein. Manches könnte nicht funktionieren oder abgeschaltet sein. Bitte überprüfe nach Updates für die gelisteten Mods.
+        FARCompatCheckKSP = \n\nDiese Mods sind inkompatibel mit KSP <<1>>.<<2>>.<<3>>:\n\n
+        FARCompatCheckUnity = \n\nDiese Mods sind inkompatibel mit Unity <<1>>:\n\n
+
+        FARFlightLogAeroFailure = [<<1>>] <<2>> versagte wegen aerodynamischer Belastung.
+
+        FARDesignConcernStabTitle = Gefährt ist aerodynamisch instabil!
+        FARDesignConcernDesc = Der aerodynamische Mittelpunkt liegt vor dem Schwerpunkt; das Gefährt braucht ausreichend Schubvektorsteuerung um Vorwärtsflug beizubehalten.
+
+        FARDesignConcernAreaRuleTitle = Hoher transonischer- / Überschallwiderstand!
+        FARDesignConcernAreaRuleDesc = Die Querschnittsflächenverteilung ist nicht glatt genug und/oder enthält sehr große plötzliche Schwankungen der Fläche.
+
+        FARAbbrevCl = Cl
+        FARAbbrevCd = Cd
+        FARAbbrevCm = Cm
+        FARAbbrevL_D = L/D
+        FARAbbrevAoA = AoA
+        FARAbbrevMach = Mach
+
+        FARUnitM = m
+        FARUnitMSq = m²
+        FARUnitMPerSec = m/s
+        FARUnitMPerSecSq = m/s²
+        FARUnitKgMSq = kg * m²
+        FARUnitDeg = °
+        FARUnitInvSec = s⁻¹
+        FARUnitInvSecSq = s⁻²
+        FARUnitInvMSec = (m * s)⁻¹
+
+        FARUnitKPa = kPa
+        FARUnitKN = kN
+        FARUnitInvHr = hr⁻¹
+        FARUnitPercent = %
+        FARUnitSpecPower = W/kg
+        FARUnitHr = hr
+        FARUnitkM = km
+        FARUnitBC = kg/m²
+
+        FAREditorTitle = FAR Analyse
+
+        FAREditorModeStatic = Statische Analyse
+        FAREditorModeDataStab = Daten- & Stabilitätsvorhersagen
+        FAREditorModeDerivSim = Stab.vorhersg. Simulation
+        FAREditorModeTrans = Transonisches Design
+
+        FARFlapSetting0 = 0 (Auf)
+        FARFlapSetting1 = 1 (Init. Steigen)
+        FARFlapSetting2 = 2 (Start)
+        FARFlapSetting3 = 3 (Landung)
+
+        FARGearToggleLower = Fahrwerk ausfahren
+        FARGearToggleRaise = Fahrwerk einfahren
+
+        FARVelIndHide = Verstecke Tempo-Anzeige
+        FARVelIndShow = Zeige Tempo-Anzeige
+
+        FARDebugVoxels = Debug Voxels anzeigen
+
+        FAREditorTitleTransonic = Transonische Flächenanalyse
+        FAREditorTransMaxArea = Maximale Querschnittsfläche:\u0020
+        FAREditorTransMach1DragArea = Mach 1 Wellenwiderstandsfläche:\u0020
+        FAREditorTransCritMach = Kritische Mach-Zahl:\u0020
+        FAREditorTransMinDragExp1 = Minimaler Wellenwiderstand wird durch eine glatte,\n\rminimale Krümmungs-Querschnittsflächen-Kurve erreicht,\n\r unter der Berücksichtigung des Einlass->Triebwerk–Rohres.
+        FAREditorTransMinDragExp2 = Minimiere Krümmung um Wellenwiderstand zu minimieren.
+        FAREditorTransAreaCurve = Zeige Kurve: Querschnittsfläche (green)
+        FAREditorTransCurvCurve = Zeige Kurve: Krümmung-Querschnittsfläche (yellow)
+        FAREditorTransPresCurve = Zeige Kurve: ⌀ des Druck-Koeffizienten (blue)
+
+        FAREditorStabDerivFlightCond = Flugumstände:
+        FAREditorStabDerivPlanet = Planet:
+        FAREditorStabDerivAlt = Höhe (km):
+        FAREditorStabDerivMach = Mach-Zahl:
+        FAREditorStabDerivFlap = Flap Setting:
+        FAREditorStabDerivSpoiler = Spoiler:
+        FAREditorStabDerivSDeploy = Ausgefahren
+        FAREditorStabDerivSRetract = Eingefahren
+
+        FAREditorStabDerivCalcButton = Berechne Stabilitätswerte
+        FAREditorStabDerivSaveButton = Stabilitätswerte speichern
+        FAREditorStabDerivLoopButton = Run Export Sweep
+        FAREditorStabDerivError = Fehler!
+        FAREditorStabDerivErrorExp = Höhe war über der Atmosphäre
+        FAREditorStabDerivSaveError = Fehler!
+        FAREditorStabDerivSaveErrorExp = Unable to export stability derivatives. You may need to delete previous exported values.
+        FAREditorStabDerivLoopDone = Calculation loop complete
+        FAREditorStabDerivLoopDoneExp = The stability derivatives export loop calculated and exported <<1>> solution result(s).
+
+        FAREditorStabDerivAirProp = Flugzeug-Eigenschaften
+        FAREditorStabDerivMoI = Trägheitsmoment
+        FAREditorStabDerivPoI = Trägheitsprodukt
+        FAREditorStabDerivLvlFl = Level-Flug
+
+        // TODO: FAREditorStabDeriv localization
+        FAREditorStabDerivRefArea = Ref Area:\u0020
+        FAREditorStabDerivScaledChord = Scaled Chord:\u0020
+        FAREditorStabDerivScaledSpan = Scaled Span:\u0020
+
+        FAREditorStabDerivIxx = Ixx:\u0020
+        FAREditorStabDerivIyy = Iyy:\u0020
+        FAREditorStabDerivIzz = Izz:\u0020
+        FAREditorStabDerivIxy = Ixy:\u0020
+        FAREditorStabDerivIyz = Iyz:\u0020
+        FAREditorStabDerivIxz = Ixz:\u0020
+
+        FAREditorStabDerivIxxExp = Trägheit um X-Achse durch Rotation um X-Achse
+        FAREditorStabDerivIyyExp = Trägheit um Y-Achse durch Rotation um Y-Achse
+        FAREditorStabDerivIzzExp = Trägheit um Z-Achse durch Rotation um Z-Achse
+        FAREditorStabDerivIxyExp = Trägheit um X-Achse durch Rotation um Y-Achse; ist gleich der Trägheit um Y-Achse durch Rotation um X-Achse
+        FAREditorStabDerivIyzExp = Trägheit um Y-Achse durch Rotation um Z-Achse; ist gleich der Trägheit um Z-Achse durch Rotation um Y-Achse
+        FAREditorStabDerivIxzExp = Trägheit um X-Achse durch Rotation um Z-Achse; ist gleich der Trägheit um Z-Achse durch Rotation um X-Achse
+
+        FAREditorStabDerivu0 = u0:\u0020
+        FAREditorStabDerivu0Exp = Lufttempo basierend auf dieser Mach-Zahl und Temperatur.
+        FAREditorStabDerivClExp = Benötigter Liftkoeffizient bei diesem Gewicht, Tempo und Luftdruck.
+        FAREditorStabDerivCdExp = Resultierender Luftwiderstandsfaktor bei diesem Gewicht, Tempo und Luftdruck.
+        FAREditorStabDerivAoAExp = Benötigter Anstellwinkel für die benötigte Kraft an Lift.
+
+        FAREditorLongDeriv = Längs-Ableitungen
+        FAREditorDownVelDeriv = Abwärts-Tempo-Ableitungen
+        FAREditorFwdVelDeriv = Vorwärts-Tempo-Ableitungen
+        FAREditorPitchRateDeriv = Nickraten-Ableitungen
+        FAREditorPitchCtrlDeriv = Nickkontroll-Ableitungen
+
+        FAREditorZw = Zw:\u0020
+        FAREditorZu = Zu:\u0020
+        FAREditorZq = Zq:\u0020
+        FAREditorZDeltae = Zδe:\u0020
+
+        FAREditorXw = Xw:\u0020
+        FAREditorXu = Xu:\u0020
+        FAREditorXq = Xq:\u0020
+        FAREditorXDeltae = Xδe:\u0020
+
+        FAREditorMw = Mw:\u0020
+        FAREditorMu = Mu:\u0020
+        FAREditorMq = Mq:\u0020
+        FAREditorMDeltae = Mδe:\u0020
+
+        FAREditorZwExp = Änderung in Z-gerichteter Beschleunigung hinsichtlich zum Tempo in Z-Richtung; sollte negativ sein.
+        FAREditorZuExp = Änderung in Z-gerichteter Beschleunigung hinsichtlich zum Tempo in X-Richtung; sollte negativ sein.
+        FAREditorZqExp = Änderung in Z-gerichteter Beschleunigung hinsichtlich zur Hochzieh-Rate; Vorzeichen unwichtig.
+        FAREditorZDeltaeExp = Änderung in Z-gerichteter Beschleunigung hinsichtlich zur Nick-Steuerung-Eingabe; Vorzeichen unwichtig.
+
+        FAREditorXwExp = Änderung in X-gerichteter Beschleunigung hinsichtlich zum Tempo in Z-Richtung; Vorzeichen unwichtig.
+        FAREditorXuExp = Änderung in X-gerichteter Beschleunigung hinsichtlich zum Tempo in X-Richtung; sollte negativ sein.
+        FAREditorXqExp = Änderung in X-gerichteter Beschleunigung hinsichtlich zur Hochzieh-Rate; Vorzeichen unwichtig.
+        FAREditorXDeltaeExp = Änderung in X-gerichteter Beschleunigung hinsichtlich zur Nick-Steuerung-Eingabe; Vorzeichen unwichtig.
+
+        FAREditorMwExp = Änderung der Hochzieh-Winkelbeschleunigung hinsichtlich zum Tempo in Z-Richtung; sollte negativ sein.
+        FAREditorMuExp = Änderung der Hochzieh-Winkelbeschleunigung hinsichtlich zum Tempo in X-Richtung; Vorzeichen unwichtig.
+        FAREditorMqExp = Änderung der Hochzieh-Winkelbeschleunigung hinsichtlich zur Hochzieh-Rate; sollte negativ sein.
+        FAREditorMDeltaeExp = Änderung der Hochzieh-Winkelbeschleunigung hinsichtlich zur Nick-Steuerung-Eingabe; sollte positiv sein.
+
+        FAREditorLatDeriv = Querableitungen
+        FAREditorSideslipDeriv = Seitengleitflug-Ableitungen
+        FAREditorRollRateDeriv = Rollraten-Ableitungen
+        FAREditorYawRateDeriv = Gierraten-Ableitungen
+
+        FAREditorYβ = Yβ:\u0020
+        FAREditorYp = Yp:\u0020
+        FAREditorYr = Yr:\u0020
+
+        FAREditorLβ = Lβ:\u0020
+        FAREditorLp = Lp:\u0020
+        FAREditorLr = Lr:\u0020
+
+        FAREditorNβ = Nβ:\u0020
+        FAREditorNp = Np:\u0020
+        FAREditorNr = Nr:\u0020
+
+        FAREditorYβExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zum Schiebewinkel β; sollte negativ sein.
+        FAREditorYpExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zur Rechts-Roll-Rate; Vorzeichen unwichtig.
+        FAREditorYrExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zur Rechts-Gier-Rate; sollte positiv sein.
+
+        FAREditorYβExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zum Schiebewinkel β; sollte negativ sein.
+        FAREditorYpExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zur Rechts-Roll-Rate; Vorzeichen unwichtig.
+        FAREditorYrExp = Änderung in Y-gerichteter Beschleunigung hinsichtlich zur Rechts-Gier-Rate; sollte positiv sein.
+
+        FAREditorLβExp = Änderung in Rechts-Roll-Winkelbeschleunigung hinsichtlich zum Schiebewinkel β; sollte negativ sein.
+        FAREditorLpExp = Änderung in Rechts-Roll-Winkelbeschleunigung hinsichtlich zur Rechts-Roll-Rate; sollte negativ sein.
+        FAREditorLrExp = Änderung in Rechts-Roll-Winkelbeschleunigung hinsichtlich zur Rechts-Gier-Rate; sollte positiv sein.
+
+        FAREditorNβExp = Änderung in Rechts-Gier-Winkelbeschleunigung hinsichtlich zum Schiebewinkel β; sollte positiv sein.
+        FAREditorNpExp = Änderung in Rechts-Gier-Winkelbeschleunigung hinsichtlich zur Rechts-Roll-Rate; Vorzeichen unwichtig.
+        FAREditorNrExp = Änderung in Rechts-Gier-Winkelbeschleunigung hinsichtlich zur Rechts-Gier-Rate; sollte negativ sein.
+
+        FAREditorSimModeLong = Längs-Sim
+        FAREditorSimModeLat = Quer-Sim
+        FAREditorSimGraphTime = Zeit (s)
+        FAREditorSimGraphParams = Parameter
+
+        FAREditorSimInit = Init
+        FAREditorSimEndTime = EndZeit:
+        FAREditorSimTimestep = dt:
+        FAREditorSimRunButton = Starte Simulation
+
+        FAREditorStaticGraphAoA = Anstellwinkel, Winkel
+        FAREditorStaticGraphMach = Mach-Zahl
+        FAREditorStaticGraphCoeff = Cl\nCd\nCm\nL/D / 10
+
+        // Is there a German translation for Sweep?
+        FAREditorStaticMachSweep = Mach-Zahl-Analyse
+        FAREditorStaticAoASweep = Anstellwinkel-Analyse
+        FAREditorStaticSwitchAoA = Schalte zu AoA Sweep
+        FAREditorStaticSwitchMach = Schalte zu Mach Sweep
+
+        FAREditorStaticPitchSetting = Pitch-Einstellung:
+
+        FAREditorStaticGraphLowLim = Untere:
+        FAREditorStaticGraphUpLim = Obere:
+        FAREditorStaticGraphPtCount = Num Pts:
+
+        FAREditorStaticSweepMach = Sweep Mach
+        FAREditorStaticSweepAoA = Sweep AoA
+
+        FARFlightAeroVizTitle = Aero-Visualisierungs-Einstellungen
+
+        FARFlightAeroVizTintCl = Färbung Cl
+        FARFlightAeroVizTintClSatWing = Vollfärbung Cl (Flügel):
+        FARFlightAeroVizTintClSatBody = Vollfärbung Cl (Körper):
+
+        FARFlightAeroVizTintCd = Färbung Cd
+        FARFlightAeroVizTintCdSatWing = Vollfärbung Cd (Flügel):
+        FARFlightAeroVizTintCdSatBody = Vollfärbung Cd (Körper):
+
+        FARFlightAeroVizTintStall = Färbung Strmg.abriss
+        FARFlightAeroVizTintStallSat = Vollfärbung Strmg. abgerissen %:
+
+        FARFlightAeroVizToggleArrows = Zeige Aero Pfeile
+
+        FARFlightAirspeedGroundspeed = Surface
+        FARFlightAirspeedIndicated = IAS
+        FARFlightAirspeedEquivalent = EAS
+
+        FARFlightInternalAirspeedGroundspeed = Srf.:\u0020
+        FARFlightInternalAirspeedIndicated = IAS:\u0020
+        FARFlightInternalAirspeedEquivalent = EAS:\u0020
+        FARFlightInternalAirspeedMach = Mach:\u0020
+
+        FARFlightAirspeedMeterPerSec = m/s
+        FARFlightAirspeedKnots = Knoten
+        FARFlightAirspeedMPH = mph
+        FARFlightAirspeedKMH = km/h
+
+        FARFlightAirspeedLabel = Wähle Bodengeschwindigkeit-Einstellung
+
+        FARFlightDataTitle = FAR Flugdaten
+        FARFlightDataOptionLabel = Anzuzeigende Flugdaten
+
+        FARFlightDataOption0 = PYR Angles
+        FARFlightDataOption1 = AoA + Sideslip
+        FARFlightDataOption2 = Dyn Druck
+        FARFlightDataOption3 = Aero Kräfte
+        FARFlightDataOption4 = Coeffs + Ref Area
+        FARFlightDataOption5 = L/D and V*L/D
+        FARFlightDataOption6 = Motor + Ansauger
+        FARFlightDataOption7 = Reichweite + Ausdauer
+        FARFlightDataOption8 = BC und Term Tempo
+
+        FARFlightData0 = Nickwinkel: \n\rRichtung: \n\rRollwinkel:
+        FARFlightData1 = Anstellwinkel: \n\rSchiebewinkel:
+        FARFlightData2 = Dyn Druck:
+        FARFlightData3 = Lift: \n\rWiderstand: \n\rSeitenkraft:
+        FARFlightData4 = Cl: \n\rCd: \n\rCy: \n\rRef Fläche:
+        FARFlightData5 = L/D: \n\rV*L/D:
+        // TODO
+        FARFlightData6 = Treibstoff-Teil: \n\rTSFC: \n\rAir Req Met: \n\rSpec. Excess Pwr:
+        FARFlightData7 = Est. Ausdauer: \n\rEst. Reichweite:
+        FARFlightData8 = BC: \n\rAbbruch V:
+
+        // English abbreviations are fine in German
+        FARFlightGUIWindowSelect0 = Flt Data
+        FARFlightGUIWindowSelect1 = Stab Aug
+        FARFlightGUIWindowSelect2 = Lufttempo
+        FARFlightGUIWindowSelect3 = Aero Viz
+
+        FARFlightGUIReynolds = Reynolds: ｢0:E2｣
+        FARFlightGUIAtmDens = Atm Dichte:\u0020
+        FARFlightGUIFltDataBtn = Flt Daten
+        FARFlightGUIFltSettings = Flt Einstellungen
+        FARFlightGUIFltAssistance = Flughilfe Einstellungen:
+
+        FARFlightSettingsTitle = FAR Einstellungen
+        FARFlightSettingsLabel = Jetzige Gruppe:
+
+        FARFlightStatusLabel = Flugstatus
+        FARFlightStatus0 = Nominal
+        FARFlightStatus1 = Strömungsabriss
+        FARFlightStatus2 = Sackflug
+        FARFlightStatus3 = Seitengleitflug
+        FARFlightStatus4 = Hoher dyn. Druck
+        FARFlightStatus5 = Aerodyn. Versagen
+
+        FARFlightStabAugLabel0 = Roll
+        FARFlightStabAugLabel1 = Gier
+        FARFlightStabAugLabel2 = Nick
+        FARFlightStabAugLabel3 = AoA
+        FARFlightStabAugLabel4 = DPCR
+
+        FARFlightStabAugLabelLong0 = Roll System
+        FARFlightStabAugLabelLong1 = Gier System
+        FARFlightStabAugLabelLong2 = Nick System
+        FARFlightStabAugLabelLong3 = AoA Limiter
+        FARFlightStabAugLabelLong4 = Dynamic Pressure Control Reduction
+
+        FARFlightStabLabel = Kontrollsystemjustierung
+        FARFlightStabPropGain = Proportionale Verstärkung:
+        FARFlightStabDerivGain = Abgeleitete Verstärkung:
+        FARFlightStabIntGain = Integrale Verstärkung:
+        FARFlightStabAoALow = Min AoA Lim:
+        FARFlightStabAoAHigh = Max AoA Lim:
+        FARFlightStabOffset = Gewünschter Punkt:
+        FARFlightStabQScaling = Dyn Druck für Kontrollskalierung:
+
+        FARActionSpoilers = Spoiler
+        FARActionIncreaseFlap = Erhöhe Klappenauslenkung
+        FARActionDecreaseFlap = Verringere Klappenauslenkung
+        FARActionDefaultLabel = Standard Action Group Belegungen
+
+        FARCtrlSurfStdTitle = Std. Ctrl
+        FARCtrlSurfStdText = Einstellungen
+        FARCtrlSurfPitch = Nick %
+        FARCtrlSurfYaw = Gier %
+        FARCtrlSurfRoll = Roll %
+        FARCtrlSurfAoA = AoA %
+        FARCtrlSurfBrakeRudder = BremsRuder %
+        FARCtrlSurfCtrlDeflect = Ctrl Aslnk
+
+        FARCtrlSurfFlapSpoiler = Klp/Splr
+        FARCtrlSurfFlap = Klappe
+        FARCtrlSurfSpoiler = Spoiler
+        FARCtrlSurfFlapActive = Aktiv
+        FARCtrlSurfFlapInActive = Inaktiv
+        FARCtrlSurfFlapSetting = Klappen Einst.
+        FARCtrlSurfFlapDeflect = Klp/Splr Aslnk
+
+        FARCtrlActionSpoiler = Aktiviere Spoiler
+        FARCtrlActionIncFlap = Erhöhe Klappenauslenkung
+        FARCtrlActionDecFlap = Verringere Klappenauslenkung
+        FARCtrlEventIncFlap = Mehr auslenken
+        FARCtrlEventDecFlap = Weniger auslenken
+
+        FARWingMassStrength = Gewicht-Kraft Multiplikator %
+        FARWingStalled = Stalled %
+
+        RCLMatNylon = Nylon
+
+        RCLStatusStowed = GEPACKT
+        RCLStatusPreDep = TEIL OFFEN
+        RCLStatusDep = OFFEN
+        RCLStatusCut = GESCHNITTEN
+
+        RCLSettingMinPres = Min Druck
+        RCLSettingAlt = Höhe
+        RCLStatusSpare = Vfg. Schirme
+        RCLStatusChuteTemp = Schirm Temp
+        RCLTempUnit = °C
+        RCLStatusMaxTemp = Max Temp
+
+        RCLEventDeploy = Schirm öffnen
+        RCLEventCut = Schirm abschneiden
+        RCLEventDisarm = Schirm deaktivieren
+        RCLEventRepack = Schirm packen
+        RCLEventToggleInfo = Info ein/aus
+
+        RCLModuleTitle = RealChute
+
+        RCLModuleInfo0 = <b>Gewicht Gehäuse</b>: <<1>>\n
+        RCLModuleInfo1 = <b>Vfg. Schirme</b>: <<1>>\n
+        RCLModuleInfo2 = <b>Auto Schnitttmepo</b>: <<1>>m/s\n
+        RCLModuleInfo3 = <b>Fallschirm Material</b>: <<1>>
+        RCLModuleInfo4 = <b>Drag Koeffizient</b>: <<1>>\n
+        RCLModuleInfo5 = <b>Max Schirm Temperatur</b>: <<1>>°C\n
+        RCLModuleInfo6 = <b>Durchmesser teilgeöffnet</b>: <<1>>m\n
+        RCLModuleInfo7 = <b>Durchmesser geöffnet</b>: <<1>>m\n
+        RCLModuleInfo8 = <b>Min Druck für Öffnung</b>: <<1>>atm\n
+        RCLModuleInfo9 = <b>Einsatzhöhe</b>: <<1>>m\n
+        RCLModuleInfo10 = <b>Tempo bei Teilöffnung</b>: <<1>>s\n
+        RCLModuleInfo11 = <b>Tempo bei Öffnung</b>: <<1>>s\n
+
+        RCLRepackErrorMessage = Nur ein Ingenieur mit Level 1 aufwärts kann einen Fallschirm packen
+        RCLDestroyMessage = <color=orange>[RealChute]: Fallschirm von <<1>>wurde durch Aerokräfte und Hitze zerstört.</color>
+
+        RCLGUITitle = RealChute Infofenster
+        RCLGUI0 = Bauteil Name: <<1>>
+        RCLGUI1 = Symmetrie-Gegenstücke: <<1>>
+        RCLGUI2 = Bauteil Gewicht: <<1>>t
+
+        RCLGUI3 = Allgemein:
+
+        RCLGUI4 = Auto Schnitttempo: <<1>>m/s
+        RCLGUI5 = Vfg. Schirme: <<1>>
+
+        RCLGUI6 = Hauptfallschirm:
+        RCLGUI7 = Material: <<1>>
+        RCLGUI8 = Drag Koeffizient <<1>>
+        RCLGUI9 = Durchmesser teilgeöffnet: <<1>>m\nArea: <<2>>m²
+        RCLGUI10 = Durchmesser geöffnet: <<1>>m\nFläche: <<2>>m²
+
+        RCLGUISafe = Einsatzsicherheit: sicher
+        RCLGUIRisky = Einsatzsicherheit: riskant
+        RCLGUIDang = Einsatzsicherheit: gefährlich
+
+        RCLGUI11 = max Schirm Temperatur: <<1>>°C
+        RCLGUI12 = momentane Schirm Temperatur: <<1>>°C
+
+        RCLGUI13 = Teilöffnungs-Druck: <<1>>Atm
+        RCLGUI14 = Öffnungs-Höhe: <<1>>m
+
+        RCLGUI15 = Dauer Teilöffnung: <<1>>s
+        RCLGUI16 = Dauer Öffnung: <<1>>s
+
+        RCLGUICopy = Zu anderen Schirmen kopieren
+        RCLGUIClose = Schließen
+
+        RCLFailDeploy = Fallschirmöffnung fehlgeschlagen.
+        RCLFailShielded = Grund: Fallschirm ist im Windschatten.
+        RCLFailGround = Grund: gestoppt & gelandet.
+        RCLFailPres = Grund: im Weltraum.
+        RCLFailOther = Grund: zu hoch.
+    }
+}


### PR DESCRIPTION
The German localization is missing the `Localization { de-de { } }` structure, and so probably doesn't work.
This pull requests fixes it.