### PR TITLE
fix nullref in CalculateTotalAeroForce

### DIFF
--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
@@ -136,7 +136,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
                 return;
             foreach (FARAeroPartModule m in _currentAeroModules)
             {
-                if (m is null || m.transform == null)
+                if (m is null || m == null)
                     continue;
                 aeroForces.AddForce(m.transform.position, m.totalWorldSpaceAeroForce);
                 aeroForces.AddTorque(m.worldSpaceTorque);

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
@@ -136,7 +136,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
                 return;
             foreach (FARAeroPartModule m in _currentAeroModules)
             {
-                if (m is null)
+                if (m is null || m.transform == null)
                     continue;
                 aeroForces.AddForce(m.transform.position, m.totalWorldSpaceAeroForce);
                 aeroForces.AddTorque(m.worldSpaceTorque);


### PR DESCRIPTION
"m is null" is false when "m == null" might actually be true. Probably because MonoBehaviour has an overridden "==" operator.
In any case, according to my tests (when there is a separated craft/debris that is far away), trying to access m.transform throws a nullref even though "m is null" is false.
related: #74