### PR TITLE
Added Dynamic Deflection for Control Surfaces Option

### DIFF
--- a/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
@@ -633,7 +633,7 @@ namespace ferram4
             double factor = 1;
             if (vessel.atmDensity > 0.01 && isDynamicDeflection)
             {
-                 factor = Math.Pow(dynamicControlStartSpeed, exponent) / Math.Pow(vessel.srfSpeed, exponent) / (vessel.atmDensity / vessel.lastBody.atmDensityASL);
+                 factor = Math.Pow(dynamicControlStartSpeed / vessel.srfSpeed, exponent) / (vessel.atmDensity / vessel.lastBody.atmDensityASL);
             }
 
             return factor.Clamp(minControl,1);

--- a/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
@@ -176,6 +176,45 @@ namespace ferram4
                        stepIncrement = 0.5f)]
         public float maxdeflectFlap = 15;
 
+        [KSPField(guiName = "FARCtrlShowDynamicDeflection", guiActiveEditor = true, guiActive = true),
+           UI_Toggle(affectSymCounterparts = UI_Scene.All,
+           scene = UI_Scene.All,
+           disabledText = "FARCtrlSurfStdText",
+           enabledText = "FARCtrlSurfStdText")]
+        private bool showDynamicDeflection = false;
+
+        [KSPField(guiName = "FARCtrlDynamicDeflection", isPersistant = true, guiActiveEditor = false, guiActive = false),
+         UI_Toggle(affectSymCounterparts = UI_Scene.All,
+                    enabledText = "FARCtrlSurfFlapActive",
+                    scene = UI_Scene.All,
+                    disabledText = "FARCtrlSurfFlapInActive")]
+        public bool isDynamicDeflection = false;
+        public bool isPrevDynamicDeflection = true;
+
+        [KSPField(guiName = "FARCtrlDynamicStartSpeed", isPersistant = true, guiActiveEditor = true, guiActive = true),
+         UI_FloatRange(affectSymCounterparts = UI_Scene.All,
+                       maxValue = 1000.0f,
+                       minValue = 0f,
+                       scene = UI_Scene.All,
+                       stepIncrement = 10f)]
+        public float dynamicControlStartSpeed = 200.0f;
+
+        [KSPField(guiName = "FARCtrlDynamicExponent", isPersistant = true, guiActiveEditor = true, guiActive = true),
+         UI_FloatRange(affectSymCounterparts = UI_Scene.All,
+               maxValue = 4.0f,
+               minValue = 0.0f,
+               scene = UI_Scene.All,
+               stepIncrement = 0.1f)]
+        public float exponent = 2f;
+
+        [KSPField(guiName = "FARCtrlDynamicMinControl", isPersistant = true, guiActiveEditor = true, guiActive = true),
+         UI_FloatRange(affectSymCounterparts = UI_Scene.All,
+                maxValue = 1f,
+                minValue = 0f,
+                scene = UI_Scene.All,
+                stepIncrement = 0.05f)]
+        public float minControl = 0.1f;
+
         protected double PitchLocation;
         protected double YawLocation;
         protected double RollLocation;
@@ -324,6 +363,20 @@ namespace ferram4
                 Fields["brakeRudder"].guiActive = showStdCtrl;
                 Fields["maxdeflect"].guiActive = showStdCtrl;
                 prevStdCtrl = showStdCtrl;
+            }
+
+            if (showDynamicDeflection != isPrevDynamicDeflection)
+            {
+                Fields["dynamicControlStartSpeed"].guiActiveEditor = showDynamicDeflection;
+                Fields["exponent"].guiActiveEditor = showDynamicDeflection;
+                Fields["minControl"].guiActiveEditor = showDynamicDeflection;
+                Fields["isDynamicDeflection"].guiActiveEditor = showDynamicDeflection;
+
+                Fields["dynamicControlStartSpeed"].guiActive = showDynamicDeflection;
+                Fields["exponent"].guiActive = showDynamicDeflection;
+                Fields["minControl"].guiActive = showDynamicDeflection;
+                Fields["isDynamicDeflection"].guiActive = showDynamicDeflection;
+                isPrevDynamicDeflection = showDynamicDeflection;
             }
 
             if (showFlpCtrl != prevFlpCtrl)
@@ -571,7 +624,19 @@ namespace ferram4
             }
 
             AoAdesiredControl *= AoAsign;
+            AoAdesiredControl *= CalculateDynamicControlFactor();
             AoAdesiredControl = AoAdesiredControl.Clamp(-Math.Abs(maxdeflect), Math.Abs(maxdeflect));
+        }
+
+        private double CalculateDynamicControlFactor()
+        {
+            double factor = 1;
+            if (vessel.atmDensity > 0.01 && isDynamicDeflection)
+            {
+                 factor = Math.Pow(dynamicControlStartSpeed, exponent) / Math.Pow(vessel.srfSpeed, exponent) / (vessel.atmDensity / vessel.lastBody.atmDensityASL);
+            }
+
+            return factor.Clamp(minControl,1);
         }
 
         public override double CalculateAoA(Vector3d velocity)
@@ -603,7 +668,7 @@ namespace ferram4
         )
         {
             double error = desired - current;
-            if (!forceSetToDesired && Math.Abs(error) >= 0.1
+            if (!forceSetToDesired && Math.Abs(error) >= 0.01
             ) // DaMichel: i changed the threshold since i noticed a "bump" at max deflection
             {
                 double tmp1 = error / blendTimeConstant;

--- a/GameData/FerramAerospaceResearch/Localization/Localization.cfg
+++ b/GameData/FerramAerospaceResearch/Localization/Localization.cfg
@@ -343,6 +343,12 @@
 		FARCtrlActionDecFlap = Decrease Flap Deflection
 		FARCtrlEventIncFlap = Deflect more
 		FARCtrlEventDecFlap = Deflect less
+		
+		FARCtrlShowDynamicDeflection = Dynamic Deflection
+		FARCtrlDynamicDeflection = Toggle Dynamic Deflection
+		FARCtrlDynamicStartSpeed = Start Speed
+		FARCtrlDynamicExponent = Reduction Exponent
+		FARCtrlDynamicMinControl = Minimal Control
 
 		FARWingMassStrength = Mass-Strength Multiplier %
 		FARWingStalled = Stalled %

--- a/GameData/FerramAerospaceResearch/Localization/Localization_de-de.cfg
+++ b/GameData/FerramAerospaceResearch/Localization/Localization_de-de.cfg
@@ -349,6 +349,12 @@ Localization
         FARCtrlActionDecFlap = Verringere Klappenauslenkung
         FARCtrlEventIncFlap = Mehr auslenken
         FARCtrlEventDecFlap = Weniger auslenken
+		
+		FARCtrlShowDynamicDeflection = Dynamische Aslnk Einst.
+		FARCtrlDynamicDeflection = Aktiviere Dynamische Aslnk
+		FARCtrlDynamicStartSpeed = Start Geschw.
+		FARCtrlDynamicExponent = Reduktionsexponent
+		FARCtrlDynamicMinControl = Minimale Kontrolle
 
         FARWingMassStrength = Gewicht-Kraft Multiplikator %
         FARWingStalled = Stalled %

--- a/GameData/FerramAerospaceResearch/Localization/Localization_ru.cfg
+++ b/GameData/FerramAerospaceResearch/Localization/Localization_ru.cfg
@@ -325,6 +325,12 @@
 		FARCtrlActionDecFlap = Уменьш. откл. закрылков
 		FARCtrlEventIncFlap = Увелич. откл.
 		FARCtrlEventDecFlap = Уменьш. откл.
+		
+		FARCtrlShowDynamicDeflection = Dynamic Deflection
+		FARCtrlDynamicDeflection = Toggle Dynamic Deflection
+		FARCtrlDynamicStartSpeed = Start Speed
+		FARCtrlDynamicExponent = Reduction Exponent
+		FARCtrlDynamicMinControl = Minimal Control
 
 		FARWingMassStrength = Коэфф-т массы+прочности
 		FARWingStalled = % сваливания

--- a/GameData/FerramAerospaceResearch/Localization/Localization_zh-cn.cfg
+++ b/GameData/FerramAerospaceResearch/Localization/Localization_zh-cn.cfg
@@ -343,6 +343,12 @@
 		FARCtrlActionDecFlap = 减少襟翼偏转
 		FARCtrlEventIncFlap = 偏转增加
 		FARCtrlEventDecFlap = 偏转减少
+		
+		FARCtrlShowDynamicDeflection = Dynamic Deflection
+		FARCtrlDynamicDeflection = Toggle Dynamic Deflection
+		FARCtrlDynamicStartSpeed = Start Speed
+		FARCtrlDynamicExponent = Reduction Exponent
+		FARCtrlDynamicMinControl = Minimal Control
 
 		FARWingMassStrength = 质量-强度 因子 %
 		FARWingStalled = 失速 %


### PR DESCRIPTION
Dynamic control adapts the actual deflection of a control surface based on speed and height.
New tunable parameters
Dynamic Deflection: Enable/Disable (this functionality=
StartSpeed: up until this speed no adaption happens. From then on the control input decreases based on the selected exponent.
Exponent: allows to tune the rate of decrease (e.g. exponent 2 reduces the deflection to 0.25x the original at 2x start speed
MinControl: The control does not decrease lower than this value)

In addition control deflection will increase linearly based on altitude (up to the original desired deflection to ensure that the plane keep maneuverability higher up).

Additional small change:
Decrease the minimal threshold of deflection. This was done to improve handling at higher speeds where a little deflection makes a big difference. This will help autopilot PID controllers as there are less "jumps" caused by the relatively high former min value

This is a video showing the changes in action [https://youtu.be/ch_f8B0YRis](url)
This graph shows how the settings influence actual deflection (e.g. at 2x the selected start speed with an exponent of 2 yu will get 0.25x the deflection [this means if it had 12 degrees max deflection it will now deflect only 4 degrees]
![DynamicDeflection](https://user-images.githubusercontent.com/34184766/116010848-defa2880-a621-11eb-8fb0-75560c973bb7.png)

I will create a small forum post with this as well