### PR TITLE
Improve Engineer's Report handling

### DIFF
--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/EditorGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/EditorGUI.cs
@@ -192,8 +192,7 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI
             GameEvents.onEditorShipModified.Add(ResetEditorEvent);
             GameEvents.onEditorLoad.Add(ResetEditorEvent);
 
-            GameEvents.onGUI
-            sReportReady.Add(AddDesignConcerns);
+            GameEvents.onGUIEngineersReportReady.Add(AddDesignConcerns);
             GameEvents.onGUIEngineersReportDestroy.Add(RemoveDesignConcerns);
 
             RequestUpdateVoxel();

--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/EditorGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/EditorGUI.cs
@@ -192,7 +192,8 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI
             GameEvents.onEditorShipModified.Add(ResetEditorEvent);
             GameEvents.onEditorLoad.Add(ResetEditorEvent);
 
-            GameEvents.onGUIEngineersReportReady.Add(AddDesignConcerns);
+            GameEvents.onGUI
+            sReportReady.Add(AddDesignConcerns);
             GameEvents.onGUIEngineersReportDestroy.Add(RemoveDesignConcerns);
 
             RequestUpdateVoxel();
@@ -201,7 +202,7 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI
         private void AddDesignConcerns()
         {
             editorReportUpdate = EngineersReport.Instance.GetType()
-                                                .GetMethod("OnCraftModified",
+                                                .GetMethod("UpdateDesignConcern",
                                                            BindingFlags.Instance | BindingFlags.NonPublic,
                                                            null,
                                                            Type.EmptyTypes,
@@ -376,6 +377,9 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI
 
                     _simManager.UpdateAeroData(_vehicleAero, _wingAerodynamicModel);
                     UpdateCrossSections();
+                    
+                    foreach (IDesignConcern designConcern in _customDesignConcerns)
+                        designConcern.Test();
                     editorReportUpdate.Invoke(EngineersReport.Instance, null);
                 }
 


### PR DESCRIPTION
Switch from calling the entire Engineer's Report craft modified method to just updating design concerns

There is (a) no need to run the bit that recalculates craft stats, nor the other design tests, and (b) this conflicts with RP-1's KCT clobbering the craft stats bit of the Engineer's Report. Upside: should be a few (bits of a) ms faster.