### PR TITLE
Suggestion for fixing massOverride

### DIFF
--- a/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
@@ -161,16 +161,12 @@ namespace ferram4
 
         private FARWingAerodynamicModel parentWing;
         private bool updateMassNextFrame;
-        [KSPField(isPersistant = true)] private float? massOverride;
+        [KSPField(isPersistant = false)] public float massOverride = float.MinValue;
 
         public float? MassOverride
         {
-            get { return massOverride; }
-            set
-            {
-                massOverride = value;
-                Fields[nameof(massMultiplier)].guiActiveEditor = value is null;
-            }
+            get { return (massOverride > float.MinValue) ? massOverride : null; }
+            set { massOverride = value ?? float.MinValue; }
         }
 
         protected double ClIncrementFromRear;
@@ -189,7 +185,11 @@ namespace ferram4
         public float GetModuleMass(float defaultMass, ModifierStagingSituation sit)
         {
             if (MassOverride is not null)
+            {
+                Fields[nameof(curWingMass)].guiActiveEditor = false;
+                Fields[nameof(massMultiplier)].guiActiveEditor = false;
                 return (float)MassOverride;
+            }
             if (massScaleReady)
                 return desiredMass - baseMass;
             return 0;
@@ -1476,7 +1476,7 @@ namespace ferram4
                 int.TryParse(node.GetValue("nonSideAttach"), out nonSideAttach);
             if (node.HasValue("MidChordSweep"))
                 double.TryParse(node.GetValue("MidChordSweep"), out MidChordSweep);
-            if (node.HasValue("MassOverride") && float.TryParse(node.GetValue("MassOverride"), out float mass))
+            if (node.HasValue("massOverride") && float.TryParse(node.GetValue("massOverride"), out float mass))
                 MassOverride = mass;
         }
 

--- a/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
@@ -166,7 +166,12 @@ namespace ferram4
         public float? MassOverride
         {
             get { return (massOverride > float.MinValue) ? massOverride : null; }
-            set { massOverride = value ?? float.MinValue; }
+            set
+            {
+                Fields[nameof(curWingMass)].guiActiveEditor = value is not null;
+                Fields[nameof(massMultiplier)].guiActiveEditor = value is not null;
+                massOverride = value ?? float.MinValue;
+            }
         }
 
         protected double ClIncrementFromRear;

--- a/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
@@ -161,7 +161,7 @@ namespace ferram4
 
         private FARWingAerodynamicModel parentWing;
         private bool updateMassNextFrame;
-        [KSPField(isPersistant = false)] public float massOverride = float.MinValue;
+        [KSPField(isPersistant = true)] public float massOverride = float.MinValue;
 
         public float? MassOverride
         {
@@ -185,11 +185,7 @@ namespace ferram4
         public float GetModuleMass(float defaultMass, ModifierStagingSituation sit)
         {
             if (MassOverride is not null)
-            {
-                Fields[nameof(curWingMass)].guiActiveEditor = false;
-                Fields[nameof(massMultiplier)].guiActiveEditor = false;
                 return (float)MassOverride;
-            }
             if (massScaleReady)
                 return desiredMass - baseMass;
             return 0;
@@ -472,6 +468,11 @@ namespace ferram4
 
 
             OnVesselPartsChange += UpdateThisWingInteractions;
+            if (MassOverride is not null)
+            {
+                Fields[nameof(curWingMass)].guiActiveEditor = false;
+                Fields[nameof(massMultiplier)].guiActiveEditor = false;
+            }
         }
 
         public void StartInitialization()


### PR DESCRIPTION
Found a way to make massOverride work, but since KSP doesn't like a value being null (the default with the previous `float? massOverride`), I used `float.MinValue` instead.

There is likely a much better way to do this.