### PR TITLE
Fix nullref with potatoroids

### DIFF
--- a/FerramAerospaceResearch/FARPartGeometry/GeometryPartModule.cs
+++ b/FerramAerospaceResearch/FARPartGeometry/GeometryPartModule.cs
@@ -366,7 +366,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
 
             if (t.gameObject.layer != ignoreLayer0)
             {
-                Transform prefabTransform = part.partInfo.partPrefab.FindModelTransform(t.gameObject.name);
+                Transform prefabTransform = part.partInfo.partPrefab?.FindModelTransform(t.gameObject.name);
                 if (prefabTransform is null || prefabTransform.gameObject.layer != ignoreLayer0)
                     return false;
             }


### PR DESCRIPTION
Not all parts have a prefab, asteroids among them.