### PR TITLE
Sanitize vessel filenames

### DIFF
--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightDataLogger.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightDataLogger.cs
@@ -251,7 +251,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
                 replacements[VesselNameKey] = Localizer.Format(Vessel.vesselName);
             replacements[DatetimeKey] = DateTime.Now.ToString(FARConfig.FlightLog.DatetimeFormat);
             string filename = Path.Combine(FARConfig.FlightLog.Directory,
-                                           FARConfig.FlightLog.NameFormat.ToString(replacements));
+                                           KSPUtil.SanitizeFilename(FARConfig.FlightLog.NameFormat.ToString(replacements)));
 
             return filename;
         }


### PR DESCRIPTION
Hi @dkavolis! A user posted a log on the forum, and I noticed this while investigating:

https://forum.kerbalspaceprogram.com/index.php?/topic/206468-having-unexpected-mark-stack-overflow-and-other-unexpected-crashes-in-a-modded-install/

Also submitted Boris-Barboris/AtmosphereAutopilot#29 for the same problem in another mod.

## Problem

If a user on Windows puts a `"` character in a vessel's name, this is seen in the log:

```
[EXC 16:28:19.888] ArgumentException: Illegal characters in path.
	System.IO.Path.Combine (System.String path1, System.String path2) (at <9577ac7a62ef43179789031239ba8798>:0)
	FerramAerospaceResearch.FARGUI.FARFlightGUI.FlightDataLogger.GetFilename () (at <5703ae4062a541a09eeee98e1716f5d5>:0)
	FerramAerospaceResearch.FARGUI.FARFlightGUI.FlightDataLogger.CreateLogger (Vessel vessel) (at <5703ae4062a541a09eeee98e1716f5d5>:0)
	FerramAerospaceResearch.FARGUI.FARFlightGUI.FlightGUI.OnStart () (at <5703ae4062a541a09eeee98e1716f5d5>:0)
	VesselModule.Start () (at <39c0323fb6b449a4aaf3465c00ed3c8d>:0)
	UnityEngine.DebugLogHandler:LogException(Exception, Object)
	ModuleManager.UnityLogHandle.InterceptLogHandler:LogException(Exception, Object)
	UnityEngine.Debug:CallOverridenDebugHandler(Exception, Object)
```

This causes the serialization to fail, which may be cascading into other problems as well:

> I have indeed noticed strange behavior on the behalf of FAR (as in the GUI not displaying any information)

## Cause

[Windows doesn't allow certain characters in filenames](https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file), including `"`, and FARc is trying to put user input into a filename without sanitizing it.

## Changes

Now this filename is passed through `KSPUtil.SanitizeFilename` before use (the same thing the stock game does with `.craft` files), so it will not contain illegal characters.
