### PR TITLE
Fix cfg syntax errors

### DIFF
--- a/GameData/FerramAerospaceResearch/FerramAerospaceResearch.cfg
+++ b/GameData/FerramAerospaceResearch/FerramAerospaceResearch.cfg
@@ -64,7 +64,7 @@
 {
 	!MODULE[KzFairingBaseShielding] { }
 }
-/Powered by ialdabaoth's ModuleManager
+//Powered by ialdabaoth's ModuleManager
 // NovaPunch2 wings.
 @PART[NP_zmisc_B5_Fin]:FOR[FerramAerospaceResearch]
 {

--- a/GameData/FerramAerospaceResearch/RealChuteLite/RealChuteLite.cfg
+++ b/GameData/FerramAerospaceResearch/RealChuteLite/RealChuteLite.cfg
@@ -8,8 +8,8 @@
         }
  
 	//Removes stock sounds
-	!sound_parachute_open
-	!sound_parachute_single
+	!sound_parachute_open = DELETE
+	!sound_parachute_single = DELETE
 
         //Effects
         EFFECTS
@@ -66,8 +66,8 @@
         }
  
 	//Removes stock sounds
-	!sound_parachute_open
-	!sound_parachute_single
+	!sound_parachute_open = DELETE
+	!sound_parachute_single = DELETE
 
         //Effects
         EFFECTS

--- a/GameData/FerramAerospaceResearch/_FARPartModule.cfg
+++ b/GameData/FerramAerospaceResearch/_FARPartModule.cfg
@@ -11,7 +11,7 @@
 }
 @PART[*]:HAS[@MODULE[FARBasicDragModel]]:AFTER[FerramAerospaceResearch]
 {
-	!MODULE[FARBasicDragModel]
+	!MODULE[FARBasicDragModel] { }
 }
 @PART[*]:HAS[!MODULE[FARWingAerodynamicModel],!MODULE[FARControllableSurface]]:AFTER[FerramAerospaceResearch]
 {


### PR DESCRIPTION
Hi @dkavolis,

I've been working on some cfg parser code for KSP-CKAN/CKAN#3525, and I tested it on this mod and found a few minor syntax errors (a comment missing `//`, deletions missing `{}` or `=`).

This pull request fixes them.

Cheers!