### PR TITLE
Fix various NREs. Calculate vessel orientation without using the NavBall, which doesn't exist in IVA mode.

### DIFF
--- a/FerramAerospaceResearch/FARAeroComponents/FARAeroSection.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/FARAeroSection.cs
@@ -143,12 +143,13 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
             Vector3 worldSpaceAvgPos = Vector3.zero;
             float totalDragFactor = 0;
+            PartTransformInfo partTransformInfo;
             for (int i = 0; i < moduleList.Count; i++)
             {
                 Part p = moduleList[i].part;
-                if (!partWorldToLocalMatrixDict.ContainsKey(p))
+                if (!partWorldToLocalMatrixDict.TryGetValue(p, out partTransformInfo))
                     continue;
-                worldSpaceAvgPos += partWorldToLocalMatrixDict[p].worldPosition * dragFactor[i];
+                worldSpaceAvgPos += partTransformInfo.worldPosition * dragFactor[i];
                 totalDragFactor += dragFactor[i];
             }
 
@@ -160,8 +161,10 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
             for (int i = 0; i < moduleList.Count; i++)
             {
-                var data = new PartData {aeroModule = moduleList[i]};
-                Matrix4x4 transformMatrix = partWorldToLocalMatrixDict[data.aeroModule.part].worldToLocalMatrix;
+                var data = new PartData { aeroModule = moduleList[i] };
+                if (!partWorldToLocalMatrixDict.TryGetValue(data.aeroModule.part, out partTransformInfo))
+                    continue;
+                Matrix4x4 transformMatrix = partTransformInfo.worldToLocalMatrix;
 
                 Vector3 forceCenterWorldSpace = centroidLocationAlongxRef +
                                                 Vector3.ProjectOnPlane(partWorldToLocalMatrixDict[data.aeroModule.part]

--- a/FerramAerospaceResearch/FARAeroComponents/VehicleAerodynamics.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/VehicleAerodynamics.cs
@@ -71,7 +71,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
         private readonly List<float> weighting = new List<float>();
 
         private VehicleVoxel _voxel;
-        private VoxelCrossSection[] _vehicleCrossSection = new VoxelCrossSection[1];
+        private VoxelCrossSection[] _vehicleCrossSection = Array.Empty<VoxelCrossSection>();
         private double[] _ductedAreaAdjustment = new double[1];
 
         private int _voxelCount;

--- a/FerramAerospaceResearch/FARAeroComponents/VehicleAerodynamics.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/VehicleAerodynamics.cs
@@ -1651,7 +1651,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
                     }
                     else if (i == back)
                     {
-                        firstDerivArea = vehicleCrossSection[i].area - vehicleCrossSection[i + 1].area;
+                        firstDerivArea = vehicleCrossSection[i - 1].area - vehicleCrossSection[i].area;
                         firstDerivArea /= sectionThickness;
                     }
                     else
@@ -1692,7 +1692,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
                     }
                     else if (i == back)
                     {
-                        firstDerivArea = vehicleCrossSection[i].area - vehicleCrossSection[i + 1].area;
+                        firstDerivArea = vehicleCrossSection[i - 1].area - vehicleCrossSection[i].area;
                         firstDerivArea /= -sectionThickness;
                     }
                     else

--- a/FerramAerospaceResearch/FARPartGeometry/VehicleVoxel.cs
+++ b/FerramAerospaceResearch/FARPartGeometry/VehicleVoxel.cs
@@ -295,7 +295,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
             threadsQueued = Environment.ProcessorCount - 1;
 
             if (!multiThreaded)
-                //Go through it backwards; this ensures that children (and so interior to cargo bay parts) are handled first
+            //Go through it backwards; this ensures that children (and so interior to cargo bay parts) are handled first
             {
                 foreach (GeometryPartModule m in geoModules)
                 {
@@ -1354,6 +1354,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
                 return;
             VoxelizationThreadpool.Instance.RunOnMainThread(() =>
             {
+                if (voxelMesh == null) { FARLogger.Debug($"Visual voxel has disappeared!"); return; }
                 FARLogger.Debug("Clearing visual voxels");
                 voxelMesh.gameObject.SetActive(false);
                 voxelMesh.Clear();

--- a/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
@@ -547,6 +547,8 @@ namespace ferram4
             float mass = 0;
             foreach (Part p in VesselPartList)
             {
+                if (p == null)
+                    continue;
                 CoM += p.transform.position * p.mass;
                 mass += p.mass;
             }

--- a/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
@@ -467,7 +467,10 @@ namespace ferram4
         public override void FixedUpdate()
         {
             if (justStarted)
+            {
+                UpdateShipPartsList();
                 CalculateSurfaceFunctions();
+            }
 
             if (HighLogic.LoadedSceneIsFlight && !(part is null) && !(vessel is null))
             {
@@ -545,7 +548,6 @@ namespace ferram4
 
             Vector3 CoM = Vector3.zero;
             float mass = 0;
-            UpdateShipPartsList();
             foreach (Part p in VesselPartList)
             {
                 CoM += p.transform.position * p.mass;

--- a/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
@@ -545,6 +545,7 @@ namespace ferram4
 
             Vector3 CoM = Vector3.zero;
             float mass = 0;
+            UpdateShipPartsList();
             foreach (Part p in VesselPartList)
             {
                 if (p == null)

--- a/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
@@ -548,8 +548,6 @@ namespace ferram4
             UpdateShipPartsList();
             foreach (Part p in VesselPartList)
             {
-                if (p == null)
-                    continue;
                 CoM += p.transform.position * p.mass;
                 mass += p.mass;
             }

--- a/FerramAerospaceResearch/LEGACYferram4/FARPartModule.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARPartModule.cs
@@ -68,6 +68,7 @@ namespace ferram4
 
         public void ForceOnVesselPartsChange()
         {
+            UpdateShipPartsList();
             OnVesselPartsChange?.Invoke();
         }
 
@@ -78,7 +79,6 @@ namespace ferram4
 
         public virtual void Initialization()
         {
-            OnVesselPartsChange = UpdateShipPartsList;
             UpdateShipPartsList();
         }
 

--- a/FerramAerospaceResearch/RealChuteLite/ChuteCalculator.cs
+++ b/FerramAerospaceResearch/RealChuteLite/ChuteCalculator.cs
@@ -24,7 +24,10 @@ namespace FerramAerospaceResearch.RealChuteLite
                 DragCube semi = prefab.DragCubes.Cubes.Find(c => c.Name == "SEMIDEPLOYED"),
                          deployed = prefab.DragCubes.Cubes.Find(c => c.Name == "DEPLOYED");
                 if (semi == null || deployed == null)
+                {
                     FARLogger.Info("" + part.title + " cannot find drag cube for RealChuteLite");
+                    continue;
+                }
                 module.preDeployedDiameter = GetApparentDiameter(semi);
                 module.deployedDiameter = GetApparentDiameter(deployed);
                 part.moduleInfos.Find(m => m.moduleName == "RealChute").info = module.GetInfo();

--- a/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
+++ b/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
@@ -443,21 +443,21 @@ namespace FerramAerospaceResearch.RealChuteLite
                 case "STOWED":
                 {
                     parachute.gameObject.SetActive(false);
-                    cap.gameObject.SetActive(true);
+                    if (cap != null) cap.gameObject.SetActive(true);
                     break;
                 }
 
                 case "RCDEPLOYED": //This is not a predeployed state, no touchy
                 {
                     parachute.gameObject.SetActive(false);
-                    cap.gameObject.SetActive(false);
+                    if (cap != null) cap.gameObject.SetActive(false);
                     break;
                 }
 
                 case "SEMIDEPLOYED": //  stock
                 {
                     parachute.gameObject.SetActive(true);
-                    cap.gameObject.SetActive(false);
+                    if (cap != null) cap.gameObject.SetActive(false);
                     // to the end of the animation
                     part.SkipToAnimationTime(semiDeployedAnimation, 0, 1);
                     break;
@@ -466,7 +466,7 @@ namespace FerramAerospaceResearch.RealChuteLite
                 case "DEPLOYED": //  stock
                 {
                     parachute.gameObject.SetActive(true);
-                    cap.gameObject.SetActive(false);
+                    if (cap != null) cap.gameObject.SetActive(false);
                     // to the end of the animation
                     part.SkipToAnimationTime(fullyDeployedAnimation, 0, 1);
                     break;
@@ -580,7 +580,7 @@ namespace FerramAerospaceResearch.RealChuteLite
             DeploymentState = DeploymentStates.STOWED;
             randomTimer.Reset();
             time = 0;
-            cap.gameObject.SetActive(true);
+            if (cap != null) cap.gameObject.SetActive(true);
             part.DragCubes.SetCubeWeight("PACKED", 1);
             part.DragCubes.SetCubeWeight("RCDEPLOYED", 0);
         }
@@ -727,7 +727,7 @@ namespace FerramAerospaceResearch.RealChuteLite
             part.Effect("rcpredeploy");
             DeploymentState = DeploymentStates.PREDEPLOYED;
             parachute.gameObject.SetActive(true);
-            cap.gameObject.SetActive(false);
+            if (cap != null) cap.gameObject.SetActive(false);
             part.PlayAnimation(semiDeployedAnimation, semiDeploymentSpeed);
             dragTimer.Start();
             part.DragCubes.SetCubeWeight("PACKED", 0);
@@ -1184,7 +1184,7 @@ namespace FerramAerospaceResearch.RealChuteLite
                 initiated = true;
                 armed = false;
                 chuteCount = maxSpares;
-                cap.gameObject.SetActive(true);
+                if (cap != null) cap.gameObject.SetActive(true);
             }
 
             float tmpPartMass = TotalMass;
@@ -1213,7 +1213,7 @@ namespace FerramAerospaceResearch.RealChuteLite
                 if (DeploymentState != DeploymentStates.STOWED)
                 {
                     part.stackIcon.SetIconColor(XKCDColors.Red);
-                    cap.gameObject.SetActive(false);
+                    if (cap != null) cap.gameObject.SetActive(false);
                 }
 
                 if (staged && IsDeployed)

--- a/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
+++ b/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
@@ -443,21 +443,21 @@ namespace FerramAerospaceResearch.RealChuteLite
                 case "STOWED":
                 {
                     parachute.gameObject.SetActive(false);
-                    if (cap != null) cap.gameObject.SetActive(true);
+                    cap?.gameObject.SetActive(true);
                     break;
                 }
 
                 case "RCDEPLOYED": //This is not a predeployed state, no touchy
                 {
                     parachute.gameObject.SetActive(false);
-                    if (cap != null) cap.gameObject.SetActive(false);
+                    cap?.gameObject.SetActive(false);
                     break;
                 }
 
                 case "SEMIDEPLOYED": //  stock
                 {
                     parachute.gameObject.SetActive(true);
-                    if (cap != null) cap.gameObject.SetActive(false);
+                    cap?.gameObject.SetActive(false);
                     // to the end of the animation
                     part.SkipToAnimationTime(semiDeployedAnimation, 0, 1);
                     break;
@@ -466,7 +466,7 @@ namespace FerramAerospaceResearch.RealChuteLite
                 case "DEPLOYED": //  stock
                 {
                     parachute.gameObject.SetActive(true);
-                    if (cap != null) cap.gameObject.SetActive(false);
+                    cap?.gameObject.SetActive(false);
                     // to the end of the animation
                     part.SkipToAnimationTime(fullyDeployedAnimation, 0, 1);
                     break;
@@ -580,7 +580,7 @@ namespace FerramAerospaceResearch.RealChuteLite
             DeploymentState = DeploymentStates.STOWED;
             randomTimer.Reset();
             time = 0;
-            if (cap != null) cap.gameObject.SetActive(true);
+            cap?.gameObject.SetActive(true);
             part.DragCubes.SetCubeWeight("PACKED", 1);
             part.DragCubes.SetCubeWeight("RCDEPLOYED", 0);
         }
@@ -727,7 +727,7 @@ namespace FerramAerospaceResearch.RealChuteLite
             part.Effect("rcpredeploy");
             DeploymentState = DeploymentStates.PREDEPLOYED;
             parachute.gameObject.SetActive(true);
-            if (cap != null) cap.gameObject.SetActive(false);
+            cap?.gameObject.SetActive(false);
             part.PlayAnimation(semiDeployedAnimation, semiDeploymentSpeed);
             dragTimer.Start();
             part.DragCubes.SetCubeWeight("PACKED", 0);
@@ -1184,7 +1184,7 @@ namespace FerramAerospaceResearch.RealChuteLite
                 initiated = true;
                 armed = false;
                 chuteCount = maxSpares;
-                if (cap != null) cap.gameObject.SetActive(true);
+                cap?.gameObject.SetActive(true);
             }
 
             float tmpPartMass = TotalMass;
@@ -1213,7 +1213,7 @@ namespace FerramAerospaceResearch.RealChuteLite
                 if (DeploymentState != DeploymentStates.STOWED)
                 {
                     part.stackIcon.SetIconColor(XKCDColors.Red);
-                    if (cap != null) cap.gameObject.SetActive(false);
+                    cap?.gameObject.SetActive(false);
                 }
 
                 if (staged && IsDeployed)


### PR DESCRIPTION
This fixes the massive performance penalty (see profiling pics) and failure to update the vessel orientation (which likely causes many other issues) in IVA mode caused by a call to `FindObjectOfType<NavBall>()` (which doesn't exist in IVA mode) in `GetNavball` (which is being called every `FixedUpdate` since it doesn't find it). It replaces the `NavBall` code with explicit calculations of the heading, pitch and roll (which I've checked to be consistent with the values from NavBall to around single precision when not in IVA mode).

![FAR - FindObjectOfType in GetNavBall in IVA view](https://user-images.githubusercontent.com/18440126/166243461-cc975baf-eb18-4200-8bba-eab72552b197.png)
![FAR-FindObjectsOfType](https://user-images.githubusercontent.com/18440126/166243482-dac0ef34-3678-4957-a243-c6f1e0dc0faa.png)

Additionally, this fixes various `NullReferenceException`s related to EVA kerbals' parachutes and parts that have been destroyed.