### PR TITLE
Zero PID error integral if there is any roll input

### DIFF
--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/StabilityAugmentation.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/StabilityAugmentation.cs
@@ -181,16 +181,19 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
                 phi *= -FARMathUtil.deg2rad;
 
-                double output = ControlStateChange(sys, phi);
 
+                // If there's any input, assume the pilot is in control
                 if (Math.Abs(state.roll - state.rollTrim) < 0.01)
                 {
+                    double output = ControlStateChange(sys, phi);
                     if (output > 1)
                         output = 1;
                     else if (output < -1)
                         output = -1;
 
                     state.roll = (float)output + state.rollTrim;
+                } else {
+                    sys.errorIntegral = 0;
                 }
             }
             else


### PR DESCRIPTION
Unless the error integral is zeroed, the pilot will wind up fighting the
roll stabilizer while banking, and then due to the accumulated error,
the plane will start contorting wildly (and possibly catastrophically)
as the PID tries to correct the error.

The input threshold of 0.01 seems to work well even with a bit of slop
in a joystick's deadzone, but might need tuning.