### PR TITLE
Fix submergedDynamicPressurekPa and dynamicPressurekPa not getting set to 0 when part becomes shielded

### DIFF
--- a/FerramAerospaceResearch/FARAeroComponents/ModularFlightIntegratorRegisterer.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/ModularFlightIntegratorRegisterer.cs
@@ -122,6 +122,8 @@ namespace FerramAerospaceResearch.FARAeroComponents
                 part.dragVectorSqrMag = part.dragVector.sqrMagnitude;
                 if (part.dragVectorSqrMag.NearlyEqual(0) || part.ShieldedFromAirstream)
                 {
+                    part.submergedDynamicPressurekPa = 0;
+                    part.dynamicPressurekPa = 0;
                     part.dragVectorMag = 0f;
                     part.dragVectorDir = Vector3.zero;
                     part.dragVectorDirLocal = Vector3.zero;


### PR DESCRIPTION
Stock MFI will always set these fields to 0 at the start of `UpdateAerodynamics` whereas the override in FAR does not. This in turn will cause a bug where the values will stay high forever if the part changes shielded state from false to true.

Ref to how I found the issue: https://discord.com/channels/319857228905447436/1115321536807718992/1122910160080347176