### PR TITLE
Optimize VesselModules

### DIFF
--- a/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
@@ -117,13 +117,6 @@ namespace FerramAerospaceResearch.FARAeroComponents
         protected override void OnStart()
         {
             FARLogger.Info("FARVesselAero on " + vessel.name + " reporting startup");
-            base.OnStart();
-
-            if (!HighLogic.LoadedSceneIsFlight)
-            {
-                enabled = false;
-                return;
-            }
 
             _currentGeoModules = new List<GeometryPartModule>();
 
@@ -159,45 +152,44 @@ namespace FerramAerospaceResearch.FARAeroComponents
             enabled = true;
         }
 
+        public override Activation GetActivation() => Activation.FlightScene | Activation.LoadedVessels;
+
         private PartModule.StartState StartState()
         {
             PartModule.StartState startState = PartModule.StartState.None;
-            if (HighLogic.LoadedSceneIsEditor)
-                startState |= PartModule.StartState.Editor;
-            else if (HighLogic.LoadedSceneIsFlight)
-                switch (vessel.situation)
-                {
-                    case Vessel.Situations.PRELAUNCH:
-                        startState |= PartModule.StartState.PreLaunch;
-                        startState |= PartModule.StartState.Landed;
-                        break;
-                    case Vessel.Situations.DOCKED:
-                        startState |= PartModule.StartState.Docked;
-                        break;
-                    case Vessel.Situations.ORBITING:
-                    case Vessel.Situations.ESCAPING:
-                        startState |= PartModule.StartState.Orbital;
-                        break;
-                    case Vessel.Situations.SUB_ORBITAL:
-                        startState |= PartModule.StartState.SubOrbital;
-                        break;
-                    case Vessel.Situations.SPLASHED:
-                        startState |= PartModule.StartState.Splashed;
-                        break;
-                    case Vessel.Situations.FLYING:
-                        startState |= PartModule.StartState.Flying;
-                        break;
-                    case Vessel.Situations.LANDED:
-                        startState |= PartModule.StartState.Landed;
-                        break;
-                }
+            switch (vessel.situation)
+            {
+                case Vessel.Situations.PRELAUNCH:
+                    startState |= PartModule.StartState.PreLaunch;
+                    startState |= PartModule.StartState.Landed;
+                    break;
+                case Vessel.Situations.DOCKED:
+                    startState |= PartModule.StartState.Docked;
+                    break;
+                case Vessel.Situations.ORBITING:
+                case Vessel.Situations.ESCAPING:
+                    startState |= PartModule.StartState.Orbital;
+                    break;
+                case Vessel.Situations.SUB_ORBITAL:
+                    startState |= PartModule.StartState.SubOrbital;
+                    break;
+                case Vessel.Situations.SPLASHED:
+                    startState |= PartModule.StartState.Splashed;
+                    break;
+                case Vessel.Situations.FLYING:
+                    startState |= PartModule.StartState.Flying;
+                    break;
+                case Vessel.Situations.LANDED:
+                    startState |= PartModule.StartState.Landed;
+                    break;
+            }
 
             return startState;
         }
 
         private void FixedUpdate()
         {
-            if (_vehicleAero == null || !vessel.loaded)
+            if (_vehicleAero == null)
                 return;
             if (_vehicleAero.CalculationCompleted)
             {

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
@@ -149,6 +149,8 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             GameEvents.onHideUI.Add(HideUI);
         }
 
+        public override Activation GetActivation() => Activation.FlightScene | Activation.LoadedVessels;
+
         private void OnDestroy()
         {
             FlightGUIDrawer.SetGUIActive(this, false);

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
@@ -74,7 +74,6 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         internal static GUIStyle buttonStyle;
 
         private readonly StringBuilder _strBuilder = new StringBuilder();
-        private Vessel _vessel;
         private FARVesselAero _vesselAero;
 
         private PhysicsCalcs _physicsCalcs;
@@ -113,12 +112,10 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
                 else
                     FARDebugAndSettings.FARDebugButtonStock.SetFalse(false);
 
-
-            _vessel = GetComponent<Vessel>();
             _vesselAero = GetComponent<FARVesselAero>();
-            _physicsCalcs = new PhysicsCalcs(_vessel, _vesselAero);
+            _physicsCalcs = new PhysicsCalcs(vessel, _vesselAero);
             _flightStatusGUI = new FlightStatusGUI();
-            _stabilityAugmentation = new StabilityAugmentation(_vessel);
+            _stabilityAugmentation = new StabilityAugmentation(vessel);
             _flightDataGUI = new FlightDataGUI();
             AeroVizGUI = new AeroVisualizationGUI();
             debugGUI = new DebugGUI();
@@ -132,11 +129,11 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
                                                   },
                                                   new[] { 0, 1, 2, 3 });
 
-            if (vesselFlightGUI.ContainsKey(_vessel))
-                vesselFlightGUI[_vessel] = this;
+            if (vesselFlightGUI.ContainsKey(vessel))
+                vesselFlightGUI[vessel] = this;
             else
-                vesselFlightGUI.Add(_vessel, this);
-            flightDataLogger = FlightDataLogger.CreateLogger(_vessel);
+                vesselFlightGUI.Add(vessel, this);
+            flightDataLogger = FlightDataLogger.CreateLogger(vessel);
 
             enabled = true;
 
@@ -145,7 +142,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
             activeFlightGUICount++;
 
-            if (_vessel == FlightGlobals.ActiveVessel || FlightGlobals.ActiveVessel == null)
+            if (vessel == FlightGlobals.ActiveVessel || FlightGlobals.ActiveVessel == null)
                 LoadConfigs();
 
             GameEvents.onShowUI.Add(ShowUI);
@@ -158,8 +155,8 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             GameEvents.onShowUI.Remove(ShowUI);
             GameEvents.onHideUI.Remove(HideUI);
             SaveConfigs();
-            if (_vessel)
-                vesselFlightGUI.Remove(_vessel);
+            if (vessel)
+                vesselFlightGUI.Remove(vessel);
             _physicsCalcs = null;
 
             _flightDataGUI?.SaveSettings();
@@ -196,7 +193,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
         public void SaveData()
         {
-            if (_vessel != FlightGlobals.ActiveVessel)
+            if (vessel != FlightGlobals.ActiveVessel)
                 return;
             SaveConfigs();
             airSpeedGUI?.SaveSettings();
@@ -246,7 +243,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
         private void Update()
         {
-            FlightGUIDrawer.SetGUIActive(this, _vessel == FlightGlobals.ActiveVessel && showGUI && showAllGUI);
+            FlightGUIDrawer.SetGUIActive(this, vessel == FlightGlobals.ActiveVessel && showGUI && showAllGUI);
             if (frameCountForSaving >= 120)
             {
                 SaveActiveData();
@@ -262,8 +259,8 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         {
             if (airSpeedGUI != null)
                 airSpeedGUI.ChangeSurfVelocity();
-            else if (_vessel != null)
-                airSpeedGUI = new AirspeedSettingsGUI(_vessel);
+            else if (vessel != null)
+                airSpeedGUI = new AirspeedSettingsGUI(vessel);
         }
 
         public void DrawGUI()
@@ -291,7 +288,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
                 buttonStyle.padding = new RectOffset(2, 2, 2, 2);
             }
 
-            if (_vessel != FlightGlobals.ActiveVessel || !showGUI || !showAllGUI)
+            if (vessel != FlightGlobals.ActiveVessel || !showGUI || !showAllGUI)
                 return;
             mainGuiRect = GUILayout.Window(GetHashCode(),
                                            mainGuiRect,


### PR DESCRIPTION
The two FAR VesselModules should only be active on loaded vessels. In particular `FlightGUI.FixedUpdate()` was rather expensive with many vessels in flight. In my test save this reduced per frame call count down from 99 to 2; median frametime from 0.83 ms to 0.23ms.
Additionally `FlightGUI` defined its own `_vessel` field instead of using `vessel` so I took the liberty of removing that.