### PR TITLE
Implement faster lookup of PartModules

### DIFF
--- a/FerramAerospaceResearch/FARAPI.cs
+++ b/FerramAerospaceResearch/FARAPI.cs
@@ -46,6 +46,7 @@ using System;
 using ferram4;
 using FerramAerospaceResearch.FARAeroComponents;
 using FerramAerospaceResearch.FARGUI.FARFlightGUI;
+using KSPCommunityFixes;
 using UnityEngine;
 
 // ReSharper disable UnusedMember.Global
@@ -222,9 +223,8 @@ namespace FerramAerospaceResearch
         {
             foreach (Part p in v.parts)
             {
-                if (!p.Modules.Contains<FARControllableSurface>())
+                if (!(p.FindModuleImplementingFast<FARControllableSurface>() is FARControllableSurface surface))
                     continue;
-                FARControllableSurface surface = p.Modules.GetModule<FARControllableSurface>();
                 surface.SetDeflection(surface.flapDeflectionLevel + 1);
             }
         }
@@ -236,9 +236,8 @@ namespace FerramAerospaceResearch
         {
             foreach (Part p in v.parts)
             {
-                if (!p.Modules.Contains<FARControllableSurface>())
+                if (!(p.FindModuleImplementingFast<FARControllableSurface>() is FARControllableSurface surface))
                     continue;
-                FARControllableSurface surface = p.Modules.GetModule<FARControllableSurface>();
                 surface.SetDeflection(surface.flapDeflectionLevel - 1);
             }
         }
@@ -252,9 +251,8 @@ namespace FerramAerospaceResearch
         {
             foreach (Part p in v.parts)
             {
-                if (!p.Modules.Contains<FARControllableSurface>())
+                if (!(p.FindModuleImplementingFast<FARControllableSurface>() is FARControllableSurface surface))
                     continue;
-                FARControllableSurface surface = p.Modules.GetModule<FARControllableSurface>();
                 if (surface.isFlap)
                     return surface.flapDeflectionLevel;
             }
@@ -269,9 +267,8 @@ namespace FerramAerospaceResearch
         {
             foreach (Part p in v.parts)
             {
-                if (!p.Modules.Contains<FARControllableSurface>())
+                if (!(p.FindModuleImplementingFast<FARControllableSurface>() is FARControllableSurface surface))
                     continue;
-                FARControllableSurface surface = p.Modules.GetModule<FARControllableSurface>();
                 surface.brake = spoilerActive;
             }
         }
@@ -285,9 +282,8 @@ namespace FerramAerospaceResearch
         {
             foreach (Part p in v.parts)
             {
-                if (!p.Modules.Contains<FARControllableSurface>())
+                if (!(p.FindModuleImplementingFast<FARControllableSurface>() is FARControllableSurface surface))
                     continue;
-                FARControllableSurface surface = p.Modules.GetModule<FARControllableSurface>();
                 if (surface.isSpoiler)
                     return surface.brake;
             }
@@ -430,7 +426,7 @@ namespace FerramAerospaceResearch
         /// Signature is (part, (drag, lift, torque)) -> (new_drag, new_lift, new_torque)</param>
         public static void SetPartAeroForceModifier(Part part, Func<Part, Vector3, Vector3> modifier)
         {
-            part.FindModuleImplementing<FARAeroPartModule>().AeroForceModifier = modifier;
+            part.FindModuleImplementingFast<FARAeroPartModule>().AeroForceModifier = modifier;
         }
 
         /// <summary>
@@ -441,7 +437,7 @@ namespace FerramAerospaceResearch
         /// Signature is (part, (drag, lift, torque)) -> (new_drag, new_lift, new_torque)</returns>
         public static Func<Part, Vector3, Vector3> GetPartAeroForceModifier(Part part)
         {
-            return part.FindModuleImplementing<FARAeroPartModule>()?.AeroForceModifier;
+            return part.FindModuleImplementingFast<FARAeroPartModule>()?.AeroForceModifier;
         }
     }
 }

--- a/FerramAerospaceResearch/FARAeroComponents/FARAeroPartModule.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/FARAeroPartModule.cs
@@ -51,6 +51,7 @@ using FerramAerospaceResearch.FARPartGeometry;
 using FerramAerospaceResearch.RealChuteLite;
 using FerramAerospaceResearch.Settings;
 using KSP.Localization;
+using KSPCommunityFixes;
 using UnityEngine;
 
 namespace FerramAerospaceResearch.FARAeroComponents
@@ -238,8 +239,8 @@ namespace FerramAerospaceResearch.FARAeroComponents
             double areaForStress = projectedArea.totalArea / 6;
             if (!FARDebugValues.allowStructuralFailures ||
                 areaForStress <= 0.1 ||
-                part.Modules.Contains<RealChuteFAR>() ||
-                part.Modules.Contains<ModuleAblator>())
+                part.HasModuleImplementingFast<RealChuteFAR>() ||
+                part.HasModuleImplementingFast<ModuleAblator>())
             {
                 partForceMaxY = double.MaxValue;
                 partForceMaxXZ = double.MaxValue;
@@ -303,17 +304,15 @@ namespace FerramAerospaceResearch.FARAeroComponents
             partTransform = part.partTransform;
 
             materialColorUpdater = new MaterialColorUpdater(partTransform, PhysicsGlobals.TemperaturePropertyID);
-            if (part.Modules.Contains<FARWingAerodynamicModel>())
-                LegacyWingModel = part.Modules.GetModule<FARWingAerodynamicModel>();
-            else if (part.Modules.Contains<FARControllableSurface>())
-                LegacyWingModel = part.Modules.GetModule<FARControllableSurface>();
+            if (part.FindModuleImplementingFast<FARWingAerodynamicModel>() is FARWingAerodynamicModel pm)
+                LegacyWingModel = pm;
+            else if (part.FindModuleImplementingFast<FARControllableSurface>() is FARControllableSurface pm2)
+                LegacyWingModel = pm2;
             else
                 LegacyWingModel = null;
 
             // For handling airbrakes aero visualization
-            stockAeroSurfaceModule = part.Modules.Contains<ModuleAeroSurface>()
-                                         ? part.Modules.GetModule<ModuleAeroSurface>()
-                                         : null;
+            stockAeroSurfaceModule = part.FindModuleImplementingFast<ModuleAeroSurface>();
         }
 
         public double ProjectedAreaWorld(Vector3 normalizedDirectionVector)
@@ -581,9 +580,8 @@ namespace FerramAerospaceResearch.FARAeroComponents
         private void ApplyAeroStressFailure()
         {
             bool failureOccured = false;
-            if (part.Modules.Contains<ModuleProceduralFairing>())
+            if (part.FindModuleImplementingFast<ModuleProceduralFairing>() is ModuleProceduralFairing fairing)
             {
-                ModuleProceduralFairing fairing = part.Modules.GetModule<ModuleProceduralFairing>();
                 fairing.ejectionForce = 0.5f;
 
                 fairing.DeployFairing();

--- a/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
@@ -47,6 +47,7 @@ using ferram4;
 using FerramAerospaceResearch.FARGUI.FARFlightGUI;
 using FerramAerospaceResearch.FARPartGeometry;
 using FerramAerospaceResearch.FARThreading;
+using KSPCommunityFixes;
 using UnityEngine;
 
 namespace FerramAerospaceResearch.FARAeroComponents
@@ -145,7 +146,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
                         geoModulesReady++;
                 }
 
-                if (!p.Modules.Contains<KerbalEVA>() && !p.Modules.Contains<FlagSite>())
+                if (!p.HasModuleImplementingFast<KerbalEVA>() && !p.HasModuleImplementingFast<FlagSite>())
                     continue;
                 FARLogger.Info("Handling Stuff for KerbalEVA / Flag");
                 g = (GeometryPartModule)p.AddModule("GeometryPartModule");
@@ -435,7 +436,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
             _updateRateLimiter = 0;
             _updateQueued = false;
-            if (vessel.rootPart.Modules.Contains<LaunchClamp>())
+            if (vessel.rootPart.HasModuleImplementingFast<LaunchClamp>())
             {
                 DisableModule();
                 return;
@@ -447,7 +448,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
                 geoModulesReady = 0;
                 foreach (Part p in vessel.Parts)
                 {
-                    GeometryPartModule g = p.Modules.GetModule<GeometryPartModule>();
+                    GeometryPartModule g = p.FindModuleImplementingFast<GeometryPartModule>();
                     if (g is null)
                         continue;
                     _currentGeoModules.Add(g);

--- a/FerramAerospaceResearch/FARAeroComponents/ModularFlightIntegratorRegisterer.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/ModularFlightIntegratorRegisterer.cs
@@ -45,6 +45,7 @@ Copyright 2022, Michael Ferrara, aka Ferram4
 using System;
 using FerramAerospaceResearch.Settings;
 using ModularFI;
+using KSPCommunityFixes;
 using UnityEngine;
 
 namespace FerramAerospaceResearch.FARAeroComponents
@@ -75,7 +76,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
             {
                 PartThermalData ptd = fi.partThermalDataList[i];
                 Part part = ptd.part;
-                FARAeroPartModule aeroModule = part.Modules.GetModule<FARAeroPartModule>();
+                FARAeroPartModule aeroModule = part.FindModuleImplementingFast<FARAeroPartModule>();
                 if (aeroModule is null)
                     continue;
 
@@ -106,7 +107,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
         private static void UpdateAerodynamics(ModularFlightIntegrator fi, Part part)
         {
             //FIXME Proper model for airbrakes
-            if (part.Modules.Contains<ModuleAeroSurface>() ||
+            if (part.HasModuleImplementingFast<ModuleAeroSurface>() ||
                 part.Modules.Contains("MissileLauncher") && part.vessel.rootPart == part)
             {
                 fi.BaseFIUpdateAerodynamics(part);
@@ -185,7 +186,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
         private static double CalculateAreaRadiative(ModularFlightIntegrator fi, Part part)
         {
-            FARAeroPartModule module = part.Modules.GetModule<FARAeroPartModule>();
+            FARAeroPartModule module = part.FindModuleImplementingFast<FARAeroPartModule>();
             return CalculateAreaRadiative(fi, part, module);
         }
 
@@ -204,7 +205,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
         private static double CalculateAreaExposed(ModularFlightIntegrator fi, Part part)
         {
-            FARAeroPartModule module = part.Modules.GetModule<FARAeroPartModule>();
+            FARAeroPartModule module = part.FindModuleImplementingFast<FARAeroPartModule>();
             return CalculateAreaExposed(fi, part, module);
         }
 
@@ -224,7 +225,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
         private static double CalculateSunArea(ModularFlightIntegrator fi, PartThermalData ptd)
         {
-            FARAeroPartModule module = ptd.part.Modules.GetModule<FARAeroPartModule>();
+            FARAeroPartModule module = ptd.part.FindModuleImplementingFast<FARAeroPartModule>();
 
             if (module is null)
                 return fi.BaseFIGetSunArea(ptd);
@@ -235,7 +236,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
         private static double CalculateBodyArea(ModularFlightIntegrator fi, PartThermalData ptd)
         {
-            FARAeroPartModule module = ptd.part.Modules.GetModule<FARAeroPartModule>();
+            FARAeroPartModule module = ptd.part.FindModuleImplementingFast<FARAeroPartModule>();
 
             if (module is null)
                 return fi.BaseFIBodyArea(ptd);

--- a/FerramAerospaceResearch/FARAeroComponents/VehicleAerodynamics.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/VehicleAerodynamics.cs
@@ -49,6 +49,7 @@ using ferram4;
 using FerramAerospaceResearch.FARPartGeometry;
 using FerramAerospaceResearch.FARPartGeometry.GeometryModification;
 using FerramAerospaceResearch.FARThreading;
+using KSPCommunityFixes;
 using UnityEngine;
 
 namespace FerramAerospaceResearch.FARAeroComponents
@@ -223,23 +224,17 @@ namespace FerramAerospaceResearch.FARAeroComponents
                 Part p = aeroModule.part;
                 if (!p)
                     continue;
-                if (p.Modules.Contains<FARWingAerodynamicModel>())
+                if (p.FindModuleImplementingFast<FARWingAerodynamicModel>() is FARWingAerodynamicModel w)
                 {
-                    var w = p.Modules.GetModule<FARWingAerodynamicModel>();
-                    if (w is null)
-                        continue;
                     w.isShielded = false;
                     w.NUFAR_ClearExposedAreaFactor();
                     _legacyWingModels.Add(w);
                 }
-                else if (p.Modules.Contains<FARControllableSurface>())
+                else if (p.FindModuleImplementingFast<FARControllableSurface>() is FARControllableSurface c)
                 {
-                    FARWingAerodynamicModel w = p.Modules.GetModule<FARControllableSurface>();
-                    if (w is null)
-                        continue;
-                    w.isShielded = false;
-                    w.NUFAR_ClearExposedAreaFactor();
-                    _legacyWingModels.Add(w);
+                    c.isShielded = false;
+                    c.NUFAR_ClearExposedAreaFactor();
+                    _legacyWingModels.Add(c);
                 }
             }
 
@@ -440,7 +435,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
                     continue;
 
                 // Could be left null if a launch clamp
-                var geoModule = p.Modules.GetModule<GeometryPartModule>();
+                var geoModule = p.FindModuleImplementingFast<GeometryPartModule>();
 
                 hitParts.Add(p);
 
@@ -448,9 +443,8 @@ namespace FerramAerospaceResearch.FARAeroComponents
                 Vector3 candVector = Vector3.zero;
 
                 //intakes are probably pointing in the direction we're gonna be going in
-                if (p.Modules.Contains<ModuleResourceIntake>())
+                if (p.FindModuleImplementingFast<ModuleResourceIntake>() is ModuleResourceIntake intake)
                 {
-                    var intake = p.Modules.GetModule<ModuleResourceIntake>();
                     Transform intakeTrans = p.FindModelTransform(intake.intakeTransformName);
                     if (!(intakeTrans is null))
                         candVector = intakeTrans.TransformDirection(Vector3.forward);
@@ -458,9 +452,9 @@ namespace FerramAerospaceResearch.FARAeroComponents
                 //aggregate wings for later calc...
                 else if (geoModule == null ||
                          geoModule.IgnoreForMainAxis ||
-                         p.Modules.Contains<FARWingAerodynamicModel>() ||
-                         p.Modules.Contains<FARControllableSurface>() ||
-                         p.Modules.Contains<ModuleWheelBase>() ||
+                         p.HasModuleImplementingFast<FARWingAerodynamicModel>() ||
+                         p.HasModuleImplementingFast<FARControllableSurface>() ||
+                         p.HasModuleImplementingFast<ModuleWheelBase>() ||
                          p.Modules.Contains("KSPWheelBase"))
                 {
                     continue;
@@ -500,10 +494,9 @@ namespace FerramAerospaceResearch.FARAeroComponents
                     hitParts.Add(q);
 
                     //intakes are probably pointing in the direction we're gonna be going in
-                    if (q.Modules.Contains<ModuleResourceIntake>())
+                    if (q.FindModuleImplementingFast<ModuleResourceIntake>() is ModuleResourceIntake intake2)
                     {
-                        var intake = q.Modules.GetModule<ModuleResourceIntake>();
-                        Transform intakeTrans = q.FindModelTransform(intake.intakeTransformName);
+                        Transform intakeTrans = q.FindModelTransform(intake2.intakeTransformName);
                         if (!(intakeTrans is null))
                             candVector += intakeTrans.TransformDirection(Vector3.forward);
                     }
@@ -1457,12 +1450,10 @@ namespace FerramAerospaceResearch.FARAeroComponents
                     if (key is null)
                         continue;
 
-                    if (!key.Modules.Contains<FARAeroPartModule>())
+                    if (!(key.FindModuleImplementingFast<FARAeroPartModule>() is FARAeroPartModule m))
                         continue;
 
-                    var m = key.Modules.GetModule<FARAeroPartModule>();
-                    if (!(m is null))
-                        includedModules.Add(m);
+                    includedModules.Add(m);
 
                     if (_moduleAndAreasDict.ContainsKey(m))
                         _moduleAndAreasDict[m] += areas;

--- a/FerramAerospaceResearch/FARAeroComponents/VesselIntakeRamDrag.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/VesselIntakeRamDrag.cs
@@ -44,6 +44,7 @@ Copyright 2022, Michael Ferrara, aka Ferram4
 
 using System;
 using System.Collections.Generic;
+using KSPCommunityFixes;
 using UnityEngine;
 
 namespace FerramAerospaceResearch.FARAeroComponents
@@ -83,10 +84,9 @@ namespace FerramAerospaceResearch.FARAeroComponents
                     continue;
                 Part p = aeroModule.part;
 
-                foreach (PartModule m in p.Modules)
+                var intakeModules = p.FindModulesImplementingReadOnly<ModuleResourceIntake>();
+                foreach (ModuleResourceIntake intake in intakeModules)
                 {
-                    if (!(m is ModuleResourceIntake intake))
-                        continue;
                     if (intake.node != null && intake.node.attachedPart != null)
                         continue;
 
@@ -105,10 +105,9 @@ namespace FerramAerospaceResearch.FARAeroComponents
                     continue;
                 Part p = aeroModule.part;
 
-                foreach (PartModule m in p.Modules)
+                var engineModules = p.FindModulesImplementingReadOnly<ModuleEngines>();
+                foreach (ModuleEngines e in engineModules)
                 {
-                    if (!(m is ModuleEngines e))
-                        continue;
                     if (FARAeroUtil.AJELoaded)
                         if (e.ClassID == AJE_JET_CLASS_ID || e.ClassID == AJE_PROP_CLASS_ID)
                         {

--- a/FerramAerospaceResearch/FARAeroUtil.cs
+++ b/FerramAerospaceResearch/FARAeroUtil.cs
@@ -47,6 +47,7 @@ using System.Collections.Generic;
 using System.IO;
 using ferram4;
 using FerramAerospaceResearch.Settings;
+using KSPCommunityFixes;
 using UnityEngine;
 
 namespace FerramAerospaceResearch
@@ -366,7 +367,7 @@ namespace FerramAerospaceResearch
         public static bool IsNonphysical(Part p)
         {
             return p.physicalSignificance == Part.PhysicalSignificance.NONE ||
-                   p.Modules.Contains<LaunchClamp>() ||
+                   p.HasModuleImplementingFast<LaunchClamp>() ||
                    HighLogic.LoadedSceneIsEditor &&
                    p != EditorLogic.RootPart &&
                    p.PhysicsSignificance == (int)Part.PhysicalSignificance.NONE;

--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/EditorGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/EditorGUI.cs
@@ -56,6 +56,7 @@ using FerramAerospaceResearch.FARThreading;
 using FerramAerospaceResearch.Resources;
 using KSP.Localization;
 using KSP.UI.Screens;
+using KSPCommunityFixes;
 using ModuleWheels;
 using PreFlightTests;
 using UnityEngine;
@@ -330,16 +331,14 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI
             {
                 if (p == null)
                     continue;
-                if (p.Modules.Contains<FARWingAerodynamicModel>())
+                if (p.FindModuleImplementingFast<FARWingAerodynamicModel>() is FARWingAerodynamicModel w)
                 {
-                    FARWingAerodynamicModel w = p.Modules.GetModule<FARWingAerodynamicModel>();
                     if (updateWingInteractions)
                         w.EditorUpdateWingInteractions();
                     _wingAerodynamicModel.Add(w);
                 }
-                else if (p.Modules.Contains<FARControllableSurface>())
+                else if (p.FindModuleImplementingFast<FARControllableSurface>() is FARControllableSurface c)
                 {
-                    FARControllableSurface c = p.Modules.GetModule<FARControllableSurface>();
                     if (updateWingInteractions)
                         c.EditorUpdateWingInteractions();
                     _wingAerodynamicModel.Add(c);
@@ -424,10 +423,7 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI
 
             foreach (Part p in partList)
             {
-                if (!p.Modules.Contains<GeometryPartModule>())
-                    continue;
-                GeometryPartModule g = p.Modules.GetModule<GeometryPartModule>();
-                if (g == null)
+                if (!(p.FindModuleImplementingFast<GeometryPartModule>() is GeometryPartModule g))
                     continue;
                 if (g.Ready)
                 {
@@ -715,9 +711,8 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI
             List<Part> partsList = EditorLogic.SortedShipList;
             foreach (Part p in partsList)
             {
-                if (p.Modules.Contains<ModuleWheelDeployment>())
+                if (p.FindModuleImplementingFast<ModuleWheelDeployment>() is ModuleWheelDeployment l)
                 {
-                    ModuleWheelDeployment l = p.Modules.GetModule<ModuleWheelDeployment>();
                     l.ActionToggle(new KSPActionParam(KSPActionGroup.Gear,
                                                       gearToggle ? KSPActionType.Activate : KSPActionType.Deactivate));
                 }

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
@@ -47,6 +47,7 @@ using System.Collections.Generic;
 using ferram4;
 using FerramAerospaceResearch.FARAeroComponents;
 using KSP.UI.Screens.Flight;
+using KSPCommunityFixes;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
@@ -276,28 +277,26 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
                     vesselInfo.dryMass += p.mass;
                 }
 
-                foreach (PartModule m in p.Modules)
-                    switch (m)
-                    {
-                        case ModuleEngines e:
-                            FuelConsumptionFromEngineModule(e,
-                                                            ref totalThrust,
-                                                            ref totalThrust_Isp,
-                                                            ref fuelConsumptionVol,
-                                                            ref airDemandVol,
-                                                            invDeltaTime);
-                            break;
-                        case ModuleResourceIntake intake:
-                        {
-                            if (intake.intakeEnabled)
-                            {
-                                airAvailableVol += intake.airFlow * intakeAirDensity / invDeltaTime;
-                                vesselInfo.fullMass -= p.Resources[intake.resourceName].amount * intakeAirDensity;
-                            }
+                var engineModules = p.FindModulesImplementingReadOnly<ModuleEngines>();
+                foreach (ModuleEngines e in engineModules)
+                {
+                    FuelConsumptionFromEngineModule(e,
+                                                    ref totalThrust,
+                                                    ref totalThrust_Isp,
+                                                    ref fuelConsumptionVol,
+                                                    ref airDemandVol,
+                                                    invDeltaTime);
+                }
 
-                            break;
-                        }
+                var intakeModules = p.FindModulesImplementingReadOnly<ModuleResourceIntake>();
+                foreach (ModuleResourceIntake intake in intakeModules)
+                {
+                    if (intake.intakeEnabled)
+                    {
+                        airAvailableVol += intake.airFlow * intakeAirDensity / invDeltaTime;
+                        vesselInfo.fullMass -= p.Resources[intake.resourceName].amount * intakeAirDensity;
                     }
+                }
             }
 
             if (totalThrust > 0)

--- a/FerramAerospaceResearch/FARPartGeometry/GeometryPartModule.cs
+++ b/FerramAerospaceResearch/FARPartGeometry/GeometryPartModule.cs
@@ -52,6 +52,7 @@ using FerramAerospaceResearch.FARGUI.FAREditorGUI;
 using FerramAerospaceResearch.FARPartGeometry.GeometryModification;
 using FerramAerospaceResearch.Settings;
 using KSP.UI.Screens;
+using KSPCommunityFixes;
 using TweakScale;
 using UnityEngine;
 
@@ -240,14 +241,14 @@ namespace FerramAerospaceResearch.FARPartGeometry
             if (ignoreLayer0 < 0)
                 ignoreLayer0 = LayerMask.NameToLayer("TransparentFX");
 
-            GeometryPartModule modulePrefab = part.partInfo.partPrefab.FindModuleImplementing<GeometryPartModule>();
+            GeometryPartModule modulePrefab = part.partInfo.partPrefab.FindModuleImplementingFast<GeometryPartModule>();
             if (modulePrefab is not null)
                 config = modulePrefab.config;
 
             if (part.collider == null &&
-                !part.Modules.Contains<ModuleWheelBase>() &&
-                !part.Modules.Contains<KerbalEVA>() &&
-                !part.Modules.Contains<FlagSite>())
+                !part.HasModuleImplementingFast<ModuleWheelBase>() &&
+                !part.HasModuleImplementingFast<KerbalEVA>() &&
+                !part.HasModuleImplementingFast<FlagSite>())
                 return;
 
             if (HighLogic.LoadedSceneIsEditor)
@@ -490,28 +491,27 @@ namespace FerramAerospaceResearch.FARPartGeometry
                 geometryUpdaters.Add(compoundUpdate);
             }
 
-            if (part.Modules.Contains<ModuleProceduralFairing>())
+            if (part.FindModulesImplementingReadOnly<ModuleProceduralFairing>() is List<PartModule> pmList &&
+                pmList.Count > 0)
             {
-                List<ModuleProceduralFairing> fairings = part.Modules.GetModules<ModuleProceduralFairing>();
-                foreach (ModuleProceduralFairing fairing in fairings)
+                foreach (ModuleProceduralFairing fairing in pmList)
                 {
                     var fairingUpdater = new StockProcFairingGeoUpdater(fairing, this);
                     geometryUpdaters.Add(fairingUpdater);
                 }
             }
 
-            if (part.Modules.Contains<ModuleJettison>())
-
+            if (part.FindModulesImplementingReadOnly<ModuleJettison>() is List<PartModule> pmList2 &&
+                pmList2.Count > 0)
             {
-                List<ModuleJettison> engineFairings = part.Modules.GetModules<ModuleJettison>();
-                foreach (ModuleJettison engineFairing in engineFairings)
+                foreach (ModuleJettison engineFairing in pmList2)
                 {
                     var fairingUpdater = new StockJettisonTransformGeoUpdater(engineFairing, this);
                     geometryUpdaters.Add(fairingUpdater);
                 }
             }
 
-            if (!part.Modules.Contains<ModuleAsteroid>())
+            if (!part.HasModuleImplementingFast<ModuleAsteroid>())
                 return;
             var asteroidUpdater = new StockProcAsteroidGeoUpdater(this);
             geometryUpdaters.Add(asteroidUpdater);
@@ -804,7 +804,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
 
                 m = mf.sharedMesh;
 
-                if (part.Modules.Contains<ModuleProceduralFairing>() || part.Modules.Contains<ModuleAsteroid>())
+                if (part.HasModuleImplementingFast<ModuleProceduralFairing>() || part.HasModuleImplementingFast<ModuleAsteroid>())
                     return new MeshData(m.vertices, m.triangles, m.bounds);
 
                 return new MeshData(m.vertices, m.triangles, m.bounds);
@@ -827,7 +827,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
             var meshList = new List<MeshData>();
             var validTransformList = new List<Transform>();
 
-            if (part.Modules.Contains<KerbalEVA>() || part.Modules.Contains<FlagSite>())
+            if (part.HasModuleImplementingFast<KerbalEVA>() || part.HasModuleImplementingFast<FlagSite>())
             {
                 FARLogger.Info("Adding vox box to Kerbal / Flag");
                 meshList.Add(CreateBoxMeshForKerbalEVA());
@@ -841,10 +841,10 @@ namespace FerramAerospaceResearch.FARPartGeometry
             Bounds colliderBounds = part.GetPartColliderBoundsInBasis(worldToLocalMatrix);
 
             bool cantUseColliders = true;
-            bool isFairing = part.Modules.Contains<ModuleProceduralFairing>() ||
+            bool isFairing = part.HasModuleImplementingFast<ModuleProceduralFairing>() ||
                              part.Modules.Contains("ProceduralFairingSide");
-            bool isDrill = part.Modules.Contains<ModuleAsteroidDrill>() ||
-                           part.Modules.Contains<ModuleResourceHarvester>();
+            bool isDrill = part.HasModuleImplementingFast<ModuleAsteroidDrill>() ||
+                           part.HasModuleImplementingFast<ModuleResourceHarvester>();
 
             //Voxelize colliders
             if ((config.forceUseColliders ||
@@ -867,10 +867,10 @@ namespace FerramAerospaceResearch.FARPartGeometry
                 }
 
 
-            if (part.Modules.Contains<ModuleJettison>())
+            if (part.FindModulesImplementingReadOnly<ModuleJettison>() is List<PartModule> jettisons &&
+                jettisons.Count > 0)
             {
-                bool variants = part.Modules.Contains<ModulePartVariants>();
-                List<ModuleJettison> jettisons = part.Modules.GetModules<ModuleJettison>();
+                bool variants = part.HasModuleImplementingFast<ModulePartVariants>();
                 var jettisonTransforms = new HashSet<string>();
                 foreach (ModuleJettison j in jettisons)
                 {

--- a/FerramAerospaceResearch/FARPartGeometry/PartGeometryExtensions.cs
+++ b/FerramAerospaceResearch/FARPartGeometry/PartGeometryExtensions.cs
@@ -45,6 +45,7 @@ Copyright 2022, Michael Ferrara, aka Ferram4
 using System.Collections.Generic;
 using System.Reflection;
 using FerramAerospaceResearch.Settings;
+using KSPCommunityFixes;
 using UnityEngine;
 
 namespace FerramAerospaceResearch.FARPartGeometry
@@ -186,7 +187,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
 
             returnList.AddRange(p.FindModelComponents<Transform>());
 
-            if (p.Modules.Contains<ModuleAsteroid>())
+            if (p.HasModuleImplementingFast<ModuleAsteroid>())
                 ProceduralAsteroidTransforms(p, returnList);
 
             foreach (Transform t in ignoredModelTransforms)
@@ -197,7 +198,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
 
         private static void ProceduralAsteroidTransforms(Part p, List<Transform> transformList)
         {
-            var asteroid = (ModuleAsteroid)p.Modules["ModuleAsteroid"];
+            var asteroid = p.FindModuleImplementingFast<ModuleAsteroid>();
             FieldInfo[] fields = asteroid.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Instance);
 
             var procAsteroid = (PAsteroid)fields[2].GetValue(asteroid);

--- a/FerramAerospaceResearch/FARPartGeometry/VehicleVoxel.cs
+++ b/FerramAerospaceResearch/FARPartGeometry/VehicleVoxel.cs
@@ -50,6 +50,7 @@ using System.Threading;
 using ferram4;
 using FerramAerospaceResearch.FARThreading;
 using FerramAerospaceResearch.Geometry;
+using KSPCommunityFixes;
 using UnityEngine;
 
 namespace FerramAerospaceResearch.FARPartGeometry
@@ -280,13 +281,13 @@ namespace FerramAerospaceResearch.FARPartGeometry
 
             if (g.HasCrossSectionAdjusters && g.MaxCrossSectionAdjusterArea > 0)
                 return int.MaxValue;
-            if (modules.Contains("ProceduralFairingSide") || modules.Contains<ModuleProceduralFairing>())
+            if (modules.Contains("ProceduralFairingSide") || g.part.HasModuleImplementingFast<ModuleProceduralFairing>())
                 return 3;
             if (modules.Contains("ProceduralFairingBase"))
                 return 2;
-            if (modules.Contains<FARControllableSurface>() ||
-                modules.Contains<ModuleRCS>() ||
-                modules.Contains<ModuleEngines>())
+            if (g.part.HasModuleImplementingFast<FARControllableSurface>() ||
+                g.part.HasModuleImplementingFast<ModuleRCS>() ||
+                g.part.HasModuleImplementingFast<ModuleEngines>())
                 return 1;
 
             return -1;

--- a/FerramAerospaceResearch/FerramAerospaceResearch.csproj
+++ b/FerramAerospaceResearch/FerramAerospaceResearch.csproj
@@ -65,6 +65,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(KSP_DIR_BUILD)\$(KSP_DATA_DIRNAME)\Managed\KSPAssets.dll</HintPath>
     </Reference>
+    <Reference Include="KSPCommunityFixes">
+      <HintPath>$(KSP_DIR_BUILD)GameData\KSPCommunityFixes\Plugins\KSPCommunityFixes.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="ModularFlightIntegrator, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(KSP_DIR_BUILD)\GameData\ModularFlightIntegrator\ModularFlightIntegrator.dll</HintPath>

--- a/FerramAerospaceResearch/LEGACYferram4/FARBaseAerodynamics.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARBaseAerodynamics.cs
@@ -45,6 +45,7 @@ Copyright 2022, Michael Ferrara, aka Ferram4
 using System.Collections.Generic;
 using FerramAerospaceResearch;
 using FerramAerospaceResearch.FARGUI.FAREditorGUI;
+using KSPCommunityFixes;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -152,9 +153,11 @@ namespace ferram4
             var parts = new List<FARBaseAerodynamics>();
 
             foreach (Part p in EditorLogic.SortedShipList)
-                foreach (PartModule m in p.Modules)
-                    if (m is FARBaseAerodynamics aerodynamics)
-                        parts.Add(aerodynamics);
+            {
+                var modules = p.FindModulesImplementingReadOnly<FARBaseAerodynamics>();
+                foreach (FARBaseAerodynamics m in modules)
+                    parts.Add(m);
+            }
 
             return parts;
         }

--- a/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARControllableSurface.cs
@@ -45,6 +45,7 @@ Copyright 2022, Michael Ferrara, aka Ferram4
 using System;
 using FerramAerospaceResearch;
 using FerramAerospaceResearch.Settings;
+using KSPCommunityFixes;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -325,9 +326,9 @@ namespace ferram4
         {
             foreach (Part p in part.symmetryCounterparts)
             {
-                foreach (PartModule m in p.Modules)
-                    if (m is FARControllableSurface controllableSurface)
-                        controllableSurface.SetDeflection(flapDeflectionLevel);
+                var modules = p.FindModulesImplementingReadOnly<FARControllableSurface>();
+                foreach (FARControllableSurface controllableSurface in modules)
+                    controllableSurface.SetDeflection(flapDeflectionLevel);
             }
         }
 
@@ -413,8 +414,8 @@ namespace ferram4
         public override void Initialization()
         {
             base.Initialization();
-            if (part.Modules.GetModule<ModuleControlSurface>())
-                part.RemoveModule(part.Modules.GetModule<ModuleControlSurface>());
+            if (part.FindModuleImplementingFast<ModuleControlSurface>() is ModuleControlSurface mcs)
+                part.RemoveModule(mcs);
 
             OnVesselPartsChange += CalculateSurfaceFunctions;
             UpdateEvents();

--- a/FerramAerospaceResearch/LEGACYferram4/FARPartModule.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARPartModule.cs
@@ -45,6 +45,7 @@ Copyright 2022, Michael Ferrara, aka Ferram4
 using System;
 using System.Collections.Generic;
 using FerramAerospaceResearch;
+using KSPCommunityFixes;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -85,10 +86,9 @@ namespace ferram4
         public void TriggerPartColliderUpdate()
         {
             //Set up part collider list to easy runtime overhead with memory churning
-            foreach (PartModule m in part.Modules)
+            var modules = part.FindModulesImplementingReadOnly<FARPartModule>();
+            foreach (FARPartModule farModule in modules)
             {
-                if (!(m is FARPartModule farModule))
-                    continue;
                 if (farModule.partColliders == null)
                     continue;
                 partColliders = farModule.partColliders;

--- a/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
+++ b/FerramAerospaceResearch/LEGACYferram4/FARWingAerodynamicModel.cs
@@ -48,6 +48,7 @@ using FerramAerospaceResearch;
 using FerramAerospaceResearch.FARAeroComponents;
 using FerramAerospaceResearch.Settings;
 using KSP.Localization;
+using KSPCommunityFixes;
 using TweakScale;
 using UnityEngine;
 
@@ -226,7 +227,7 @@ namespace ferram4
 
         public void NUFAR_CalculateExposedAreaFactor()
         {
-            FARAeroPartModule a = part.Modules.GetModule<FARAeroPartModule>();
+            FARAeroPartModule a = part.FindModuleImplementingFast<FARAeroPartModule>();
 
             NUFAR_areaExposedFactor = Math.Min(a.ProjectedAreas.kN, a.ProjectedAreas.kP);
             NUFAR_totalExposedAreaFactor = Math.Max(a.ProjectedAreas.kN, a.ProjectedAreas.kP);
@@ -244,8 +245,8 @@ namespace ferram4
                 if (p == null)
                     continue;
                 FARWingAerodynamicModel model = this is FARControllableSurface
-                                                    ? p.Modules.GetModule<FARControllableSurface>()
-                                                    : p.Modules.GetModule<FARWingAerodynamicModel>();
+                                                    ? p.FindModuleImplementingFast<FARControllableSurface>()
+                                                    : p.FindModuleImplementingFast<FARWingAerodynamicModel>();
 
                 ++counterpartsCount;
                 sum += model.NUFAR_areaExposedFactor;
@@ -264,8 +265,8 @@ namespace ferram4
                 if (p == null)
                     continue;
                 FARWingAerodynamicModel model = this is FARControllableSurface
-                                                    ? p.Modules.GetModule<FARControllableSurface>()
-                                                    : p.Modules.GetModule<FARWingAerodynamicModel>();
+                                                    ? p.FindModuleImplementingFast<FARControllableSurface>()
+                                                    : p.FindModuleImplementingFast<FARWingAerodynamicModel>();
 
                 model.NUFAR_areaExposedFactor = sum;
                 model.NUFAR_totalExposedAreaFactor = totalExposedSum;

--- a/FerramAerospaceResearch/RealChuteLite/ChuteCalculator.cs
+++ b/FerramAerospaceResearch/RealChuteLite/ChuteCalculator.cs
@@ -1,4 +1,5 @@
 using System;
+using KSPCommunityFixes;
 using UnityEngine;
 
 /* RealChuteLite is the work of Christophe Savard (stupid_chris), and is licensed the same way than the rest of FAR is.
@@ -16,10 +17,9 @@ namespace FerramAerospaceResearch.RealChuteLite
             foreach (AvailablePart part in PartLoader.Instance.loadedParts)
             {
                 Part prefab = part.partPrefab;
-                if (prefab == null || !prefab.Modules.Contains<RealChuteFAR>())
+                if (prefab == null || !(prefab.FindModuleImplementingFast<RealChuteFAR>() is RealChuteFAR module))
                     continue;
                 //Updates the part's GetInfo.
-                RealChuteFAR module = prefab.Modules.GetModule<RealChuteFAR>();
                 DragCubeSystem.Instance.LoadDragCubes(prefab);
                 DragCube semi = prefab.DragCubes.Cubes.Find(c => c.Name == "SEMIDEPLOYED"),
                          deployed = prefab.DragCubes.Cubes.Find(c => c.Name == "DEPLOYED");

--- a/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
+++ b/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
@@ -6,6 +6,7 @@ using System.Text;
 using FerramAerospaceResearch.PartExtensions;
 using KSP.Localization;
 using KSP.UI.Screens;
+using KSPCommunityFixes;
 using UnityEngine;
 using Random = System.Random;
 
@@ -594,8 +595,8 @@ namespace FerramAerospaceResearch.RealChuteLite
             {
                 var parachutes = new List<RealChuteFAR>();
                 if (HighLogic.LoadedSceneIsEditor)
-                    parachutes.AddRange(EditorLogic.SortedShipList.Where(p => p.Modules.Contains<RealChuteFAR>())
-                                                   .Select(p => p.Modules.GetModule<RealChuteFAR>()));
+                    parachutes.AddRange(EditorLogic.SortedShipList.Where(p => p.HasModuleImplementingFast<RealChuteFAR>())
+                                                   .Select(p => p.FindModuleImplementingFast<RealChuteFAR>()));
                 else if (HighLogic.LoadedSceneIsFlight)
                     parachutes.AddRange(vessel.FindPartModulesImplementing<RealChuteFAR>());
                 if (parachutes.Count > 1 && parachutes.Exists(p => p.visible))
@@ -658,7 +659,7 @@ namespace FerramAerospaceResearch.RealChuteLite
         {
             foreach (Part p in part.symmetryCounterparts)
             {
-                var module = (RealChuteFAR)p.Modules["RealChuteFAR"];
+                var module = p.FindModuleImplementingFast<RealChuteFAR>();
                 module.minAirPressureToOpen = minAirPressureToOpen;
                 module.deployAltitude = deployAltitude;
             }
@@ -1267,7 +1268,7 @@ namespace FerramAerospaceResearch.RealChuteLite
 
             Part prefab = part.partInfo.partPrefab;
             massDelta = prefab == null ? 0 : TotalMass - prefab.mass;
-            shieldedCanDeploy = prefab.FindModuleImplementing<RealChuteFAR>().shieldedCanDeploy;
+            shieldedCanDeploy = prefab.FindModuleImplementingFast<RealChuteFAR>().shieldedCanDeploy;
         }
 
         public override void OnActive()

--- a/FerramAerospaceResearch/Settings/FARAeroStress.cs
+++ b/FerramAerospaceResearch/Settings/FARAeroStress.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using FerramAerospaceResearch.Reflection;
+using KSPCommunityFixes;
 
 namespace FerramAerospaceResearch.Settings
 {
@@ -86,7 +87,7 @@ namespace FerramAerospaceResearch.Settings
 
             int resCount = p.Resources.Count;
             bool crewed = p.CrewCapacity > 0;
-            if (p.Modules.Contains<ModuleAblator>() || p.Resources.Contains("Ablator"))
+            if (p.HasModuleImplementingFast<ModuleAblator>() || p.Resources.Contains("Ablator"))
                 return template;
 
             foreach (FARPartStressTemplate candidate in StressTemplates)


### PR DESCRIPTION
This means adding a dependency for KSPCF though.
I tried to preserve the original behavior of code wherever possible but some `PartModule is null` checks got removed. However I don't believe these were actually necessary.