### PR TITLE
Do not update drag cube areas and exposure stats

### DIFF
--- a/FerramAerospaceResearch/FARAeroComponents/ModularFlightIntegratorRegisterer.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/ModularFlightIntegratorRegisterer.cs
@@ -79,9 +79,9 @@ namespace FerramAerospaceResearch.FARAeroComponents
                 if (aeroModule is null)
                     continue;
 
-                // make sure drag cube areas are correct based on voxelization
-                if (voxelizationCompleted)
+                if (voxelizationCompleted && !FARSettings.ExposedAreaUsesKSPHack)
                 {
+                    // make sure drag cube areas are correct based on voxelization
                     if (!part.DragCubes.None && aeroModule)
                         for (int j = 0; j < 6; j++)
                             part.DragCubes.AreaOccluded[FARAeroPartModule.ProjectedArea.FaceMap[j]] =


### PR DESCRIPTION
Problem is that FAR doesn't have a properly implemented + tested re entry heating feature but some aspects of it are nonetheless enabled. Overwriting drag cube occlusion and part exposed area are one of those. Because voxels have issues with small details and thin heatshields in general, this can sometimes make heating very finicky. This PR hides those features behind the `ExposedAreaUsesKSPHack` toggle.