### PR TITLE
Default exposure rendering to off

### DIFF
--- a/FerramAerospaceResearch.Base/Resources/Device.cs
+++ b/FerramAerospaceResearch.Base/Resources/Device.cs
@@ -2,8 +2,8 @@ namespace FerramAerospaceResearch.Resources;
 
 public enum Device
 {
+        None,
         PreferGPU,
         CPU,
-        GPU,
-        None,
+        GPU
 }

--- a/FerramAerospaceResearch/FARAeroComponents/VehicleExposure.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/VehicleExposure.cs
@@ -20,7 +20,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
             Body
         };
 
-        public static readonly Device[] DeviceOptions = { Device.PreferGPU, Device.CPU, Device.GPU, Device.None };
+        public static readonly Device[] DeviceOptions = { Device.None, Device.PreferGPU, Device.CPU, Device.GPU };
         public static readonly Direction[] DirectionOptions = { Direction.Airstream, Direction.Sun, Direction.Body };
 
         private readonly Renderer<Part> exposureRenderer = new();
@@ -132,10 +132,10 @@ namespace FerramAerospaceResearch.FARAeroComponents
         {
             deviceSelect = new GUIDropDown<Device>(new[]
                                                    {
+                                                       LocalizerExtensions.Get("FARDeviceNone"),
                                                        LocalizerExtensions.Get("FARDevicePreferGPU"),
                                                        LocalizerExtensions.Get("FARDeviceCPU"),
                                                        LocalizerExtensions.Get("FARDeviceGPU"),
-                                                       LocalizerExtensions.Get("FARDeviceNone"),
                                                    },
                                                    DeviceOptions,
                                                    DeviceOptions.IndexOf(ComputeDevice));

--- a/GameData/FerramAerospaceResearch/FARConfig.cfg
+++ b/GameData/FerramAerospaceResearch/FARConfig.cfg
@@ -153,11 +153,11 @@ FARConfig
         body = false
 
         // which device part areas will be counted on, one of:
+        //  None - disable rendering
         //  PreferGPU - use GPU if your system supports compute shaders, CPU otherwise [recommended]
         //  CPU - use burst job
         //  GPU - use GPU (almost identical to PreferGPU)
-        //  None - disable rendering
-        device = PreferGPU
+        device = None
 
         // debug window background color
         debugBackgroundColor = 0, 0, 0 // black


### PR DESCRIPTION
It kinda was off previously too but when the user made changes to some of the other options in the exposure rendering window, it started running continously over scene changes and game restarts. Being an unfinished feature, it has some performance issues that compound over many scene changes.
The value defaulting to None should make it more clear for when the debug rendering is actually enabled.