### PR TITLE
Add support and docs for building on Linux

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ Unity/FerramAerospaceResearch*/.idea
 # burst compiler
 Logs/*
 Unity/FerramAerospaceResearch/Screenshots/
+
+# Nix
+.direnv

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <KSP_DATA_DIRNAME>KSP_x64_Data</KSP_DATA_DIRNAME>
     <UNITY_EDITOR_MANAGED_DIR>C:\Program Files\Unity\Hub\Editor\2019.4.18f1\Editor\Data\Managed\UnityEngine</UNITY_EDITOR_MANAGED_DIR>
     <PostBuildCommand>
-      cd "$(SolutionDir)""
+      cd "$(SolutionDir)"
       python -m buildtools postbuild --dump-events -f "$(SolutionDir)config.json" -c "$(Configuration)" -t</PostBuildCommand>
   </PropertyGroup>
   <Import Project="Directory.Build.props.user" Condition=" Exists('Directory.Build.props.user') " />

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Create a file called `Directory.Build.props.user` with the following content:
 <Project>
   <PropertyGroup>
     <KSP_DIR_BUILD>your/path/to/Kerbal Space Program</KSP_DIR_BUILD>
-    <KSP_DATA_DIRNAME>KSP_x64_Data</KSP_DATA_DIRNAME>
+    <KSP_DATA_DIRNAME>KSP_Data</KSP_DATA_DIRNAME>
   </PropertyGroup>
 </Project>
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,53 @@ For control surfaces, use above but replace `FARWingAerodynamicModel` with `FARC
 
 Set all the other winglet/control surface values to zero
 
+## Development on Linux
+
+If developing on Linux, you will need the following tools:
+
+- [Mono 6](https://www.mono-project.com/download/stable/)
+- [msbuild](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild?view=visualstudio)
+- Python 3
+
+You can also use the included [flake.nix](./flake.nix) to manage your development environment, either using direnv or by running `nix develop`.
+
+You will need an installation of Kerbal Space Program with the following addons:
+
+- [Harmony](https://github.com/KSPModdingLibs/HarmonyKSP)
+- [Burst](https://github.com/KSPModdingLibs/KSPBurst)
+    - On Linux, only the non-compiler version works
+- [ModuleManager](https://ksp.sarbian.com/jenkins/job/ModuleManager/)
+- [ModularFlightIntegrator](https://ksp.sarbian.com/jenkins/job/ModularFlightIntegrator/)
+
+You can also install these via CKAN.
+
+Create a file called `Directory.Build.props.user` with the following content:
+
+```
+<Project>
+  <PropertyGroup>
+    <KSP_DIR_BUILD>your/path/to/Kerbal Space Program</KSP_DIR_BUILD>
+    <KSP_DATA_DIRNAME>KSP_x64_Data</KSP_DATA_DIRNAME>
+  </PropertyGroup>
+</Project>
+```
+
+and replace `your/path/to/Kerbal Space Program`.
+
+Download the git submodules:
+
+```bash
+git submodule update --init --recursive
+```
+
+Now, simply run:
+
+```bash
+msbuild
+```
+
+It should result in FAR being installed into your `GameData`.
+
 ## CHANGELOG
 
 0.16.1.2V "Marangoni"------------------------------------  

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
         "ModDir": "$(SolutionDir)/$(ModDirRelative)",
         "PluginDir": "$(ModDir)/Plugins",
         "AssetDir": "$(ModDir)/Assets",
-        "KSP_DIR_INSTALL": "C:/Zaidimai/KSP 1.12",
+        "KSP_DIR_INSTALL": "$(KSP_DIR_BUILD)",
         "KSPGameData": "$(KSP_DIR_INSTALL)/GameData",
         "GameDir": "$(KSPGameData)/$(ModName)",
         "VersionMajor": 0,

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775423009,
+        "narHash": "sha256-vPKLpjhIVWdDrfiUM8atW6YkIggCEKdSAlJPzzhkQlw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "68d8aa3d661f0e6bd5862291b5bb263b2a6595c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  description = "Ferram Aerospace Research";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in {
+        devShell = pkgs.mkShell {
+          buildInputs = [
+            # pkgs.dotnet-sdk
+            pkgs.mono6
+            pkgs.msbuild
+            pkgs.python3
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,6 +11,7 @@
       in {
         devShell = pkgs.mkShell {
           buildInputs = [
+            # May be needed by your editor
             # pkgs.dotnet-sdk
             pkgs.mono6
             pkgs.msbuild


### PR DESCRIPTION
There isn't really a section on building on Windows either, but at least this would add a Linux section.

Also:

- removed that extra quote in Directory.Build.props that seems to be added by mistake
- Wired KSP_DIR_INSTALL to KSP_DIR_BUILD